### PR TITLE
chore: release v1.3.1

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -7,7 +7,6 @@ on:
       - main
     paths:
       - npm/package.json # Please only commit this file, so we don't need to wait for test CI to pass.
-  pull_request: null
 
 env:
   DEBUG: napi:*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1](https://github.com/unrs/unrs-resolver/compare/unrs_resolver-v1.3.0...unrs_resolver-v1.3.1) - 2025-03-26
+
+### Other
+
+- bump all (dev) deps ([#34](https://github.com/unrs/unrs-resolver/pull/34))
+
 ## [1.3.0](https://github.com/unrs/unrs-resolver/compare/unrspack-resolver-v1.2.2...unrs_resolver-v1.3.0) - 2025-03-26
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,7 +1190,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "unrs_resolver"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["UnRS"]
 categories = ["development-tools"]
 edition = "2024"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Oxc Resolver Node API with PNP support",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION


## 🤖 New release

* `unrs_resolver`: 1.3.0 -> 1.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.1](https://github.com/unrs/unrs-resolver/compare/unrs_resolver-v1.3.0...unrs_resolver-v1.3.1) - 2025-03-26

### Other

- bump all (dev) deps ([#34](https://github.com/unrs/unrs-resolver/pull/34))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).