### PR TITLE
fix: absolute aliasing should not be skipped

### DIFF
--- a/fixtures/tsconfig/cases/absolute-alias/public/images/foo.ts
+++ b/fixtures/tsconfig/cases/absolute-alias/public/images/foo.ts
@@ -1,0 +1,1 @@
+export default 'image.webp'

--- a/fixtures/tsconfig/cases/absolute-alias/test.ts
+++ b/fixtures/tsconfig/cases/absolute-alias/test.ts
@@ -1,0 +1,3 @@
+import image from '/images/foo.js'
+
+console.log(image)

--- a/fixtures/tsconfig/cases/absolute-alias/tsconfig.json
+++ b/fixtures/tsconfig/cases/absolute-alias/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "/*": ["./public/*"]
+    }
+  }
+}

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -26,6 +26,7 @@ fn tsconfig() {
         (f.join("cases/extends-extensionless"), None, "foo", f.join("node_modules/tsconfig-field/foo.js")),
         (f.join("cases/extends-paths"), Some("src"), "@/index", f.join("cases/extends-paths/src/index.js")),
         (f.join("cases/extends-multiple"), None, "foo", f.join("cases/extends-multiple/foo.js")),
+        (f.join("cases/absolute-alias"), None, "/images/foo.js", f.join("cases/absolute-alias/public/images/foo.ts")),
     ];
 
     for (dir, subdir, request, expected) in pass {
@@ -34,6 +35,7 @@ fn tsconfig() {
                 config_file: dir.join("tsconfig.json"),
                 references: TsconfigReferences::Auto,
             }),
+            extension_alias: vec![(".js".into(), vec![".js".into(), ".ts".into(), ".tsx".into()])],
             ..ResolveOptions::default()
         });
         let path = subdir.map_or(dir.clone(), |subdir| dir.join(subdir));

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -161,7 +161,7 @@ pub trait TsConfig: Sized {
     // <https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/tsconfig.rs#L93>
     #[must_use]
     fn resolve_path_alias(&self, specifier: &str) -> Vec<PathBuf> {
-        if specifier.starts_with(['/', '.']) {
+        if specifier.starts_with('.') {
             return Vec::new();
         }
 


### PR DESCRIPTION
close https://github.com/import-js/eslint-import-resolver-typescript/issues/401