### PR TITLE
feat: merge from upstream `oxc-project/oxc-resolver` - 3rd

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -83,6 +83,14 @@ jobs:
             target: powerpc64le-unknown-linux-gnu
             build: pnpm build --use-napi-cross
           - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            build: |
+              sudo apt-get update &&
+              sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu -y &&
+              export CC=riscv64-linux-gnu-gcc &&
+              export CXX=riscv64-linux-gnu-g++ &&
+              pnpm build
+          - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
             build: export CFLAGS="-fuse-ld=lld" && pnpm build --use-napi-cross
           - os: macos-latest
@@ -126,11 +134,11 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
+          if-no-files-found: error
           name: bindings-${{ matrix.target }}
           path: |
             napi/*.node
             napi/*.wasm
-          if-no-files-found: error
 
   build-freebsd:
     needs: check

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run release-plz
         id: release-plz
-        uses: MarcoIeni/release-plz-action@7419a2cb1535b9c0e852b4dec626967baf65c022 # v0.5
+        uses: MarcoIeni/release-plz-action@7419a2cb1535b9c0e852b4dec626967baf65c022 # v0.5.102
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
 dependencies = [
  "shlex",
 ]
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e744216bfa9add3b1f2505587cbbb837923232ed10963609f4a6e3cbd99c3e"
+checksum = "d228291b19e82cdef59c17e595c45d482e12c4ddcc9546d2f1cbd1ef28b72af5"
 dependencies = [
  "colored 2.2.0",
  "libc",
@@ -349,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -476,9 +476,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags",
 ]
@@ -1032,9 +1032,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "strsim"
@@ -1331,11 +1331,37 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1343,6 +1369,24 @@ name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "paths": {
-      "foo": ["${configDir}/foo.js"]
+      "foo": ["${configDir}/src/foo.js"]
     }
   }
 }

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig1.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig1.json
@@ -1,3 +1,0 @@
-{
-  "extends":	"../../tsconfig_template_variable.json"
-}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig_base_url1.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig_base_url1.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "${configDir}",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig_base_url2.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig_base_url2.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "${configDir}/",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends1.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends1.json
@@ -1,0 +1,3 @@
+{
+  "extends":	"../../tsconfig_template_variable1.json"
+}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends2.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends2.json
@@ -1,0 +1,3 @@
+{
+  "extends":	"../../tsconfig_template_variable2.json"
+}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends3.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends3.json
@@ -1,0 +1,3 @@
+{
+  "extends":	"../../tsconfig_template_variable3.json"
+}

--- a/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends4.json
+++ b/fixtures/tsconfig/cases/paths_template_variable/tsconfig_extends4.json
@@ -1,0 +1,3 @@
+{
+  "extends":	"../../tsconfig_template_variable4.json"
+}

--- a/fixtures/tsconfig/cases/project_references/app/tsconfig.json
+++ b/fixtures/tsconfig/cases/project_references/app/tsconfig.json
@@ -17,7 +17,7 @@
       "path": "../project_c/tsconfig.json"
     },
     {
-      "path": "../../paths_template_variable/tsconfig2.json"
+      "path": "../../paths_template_variable/tsconfig.json"
     }
   ]
 }

--- a/fixtures/tsconfig/cases/project_references/app/tsconfig.nopaths.json
+++ b/fixtures/tsconfig/cases/project_references/app/tsconfig.nopaths.json
@@ -14,7 +14,7 @@
       "path": "../project_c/tsconfig.json"
     },
     {
-      "path": "../../paths_template_variable/tsconfig2.json"
+      "path": "../../paths_template_variable/tsconfig.json"
     }
   ]
 }

--- a/fixtures/tsconfig/tsconfig.json
+++ b/fixtures/tsconfig/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
-      "ts-path": ["foo.js"]
+      "ts-path": ["src/foo.js"]
     }
   }
 }

--- a/fixtures/tsconfig/tsconfig_template_variable1.json
+++ b/fixtures/tsconfig/tsconfig_template_variable1.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "paths": {
-      "foo": ["${configDir}/foo.js"]
+      "foo": ["${configDir}/src/foo.js"]
     }
   }
 }

--- a/fixtures/tsconfig/tsconfig_template_variable2.json
+++ b/fixtures/tsconfig/tsconfig_template_variable2.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "${configDir}",
+    "paths": {
+      "foo": ["./src/foo.js"]
+    }
+  }
+}

--- a/fixtures/tsconfig/tsconfig_template_variable3.json
+++ b/fixtures/tsconfig/tsconfig_template_variable3.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "foo": ["${configDir}/src/foo.js"]
+    }
+  }
+}

--- a/fixtures/tsconfig/tsconfig_template_variable4.json
+++ b/fixtures/tsconfig/tsconfig_template_variable4.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": "${configDir}",
+    "paths": {
+      "foo": ["${configDir}/src/foo.js"]
+    }
+  }
+}

--- a/napi/Cargo.toml
+++ b/napi/Cargo.toml
@@ -24,6 +24,3 @@ mimalloc-safe = { version = "0.1.50", features = ["skip_collect_on_exit", "local
 
 [build-dependencies]
 napi-build = "2.1.6"
-
-[package.metadata.cargo-machete]
-ignored = ["napi"]

--- a/npm/package.json
+++ b/npm/package.json
@@ -38,6 +38,7 @@
       "aarch64-unknown-linux-musl",
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
+      "riscv64gc-unknown-linux-gnu",
       "powerpc64le-unknown-linux-gnu",
       "s390x-unknown-linux-gnu",
       "x86_64-apple-darwin",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "test": "vitest run -r ./napi"
   },
   "devDependencies": {
-    "@napi-rs/cli": "3.0.0-alpha.77",
+    "@napi-rs/cli": "^3.0.0-alpha.77",
     "@napi-rs/wasm-runtime": "^0.2.8",
     "@types/node": "^22.14.0",
     "emnapi": "^1.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.1.1"
   },
-  "packageManager": "pnpm@10.7.1"
+  "packageManager": "pnpm@10.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@napi-rs/cli':
-        specifier: 3.0.0-alpha.77
+        specifier: ^3.0.0-alpha.77
         version: 3.0.0-alpha.77(@emnapi/runtime@1.4.0)(@types/node@22.14.0)(emnapi@1.4.0)
       '@napi-rs/wasm-runtime':
         specifier: ^0.2.8
@@ -248,8 +248,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/checkbox@4.1.4':
-    resolution: {integrity: sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==}
+  '@inquirer/checkbox@4.1.5':
+    resolution: {integrity: sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -257,8 +257,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.8':
-    resolution: {integrity: sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==}
+  '@inquirer/confirm@5.1.9':
+    resolution: {integrity: sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -266,8 +266,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.1.9':
-    resolution: {integrity: sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==}
+  '@inquirer/core@10.1.10':
+    resolution: {integrity: sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -275,8 +275,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.9':
-    resolution: {integrity: sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==}
+  '@inquirer/editor@4.2.10':
+    resolution: {integrity: sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -284,8 +284,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@4.0.11':
-    resolution: {integrity: sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==}
+  '@inquirer/expand@4.0.12':
+    resolution: {integrity: sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -297,8 +297,8 @@ packages:
     resolution: {integrity: sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==}
     engines: {node: '>=18'}
 
-  '@inquirer/input@4.1.8':
-    resolution: {integrity: sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==}
+  '@inquirer/input@4.1.9':
+    resolution: {integrity: sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -306,8 +306,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/number@3.0.11':
-    resolution: {integrity: sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==}
+  '@inquirer/number@3.0.12':
+    resolution: {integrity: sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -315,8 +315,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.11':
-    resolution: {integrity: sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==}
+  '@inquirer/password@4.0.12':
+    resolution: {integrity: sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -324,8 +324,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@7.4.0':
-    resolution: {integrity: sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==}
+  '@inquirer/prompts@7.4.1':
+    resolution: {integrity: sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -333,8 +333,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.0.11':
-    resolution: {integrity: sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==}
+  '@inquirer/rawlist@4.0.12':
+    resolution: {integrity: sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -342,8 +342,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/search@3.0.11':
-    resolution: {integrity: sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==}
+  '@inquirer/search@3.0.12':
+    resolution: {integrity: sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -351,8 +351,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/select@4.1.0':
-    resolution: {integrity: sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==}
+  '@inquirer/select@4.1.1':
+    resolution: {integrity: sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -360,8 +360,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/type@3.0.5':
-    resolution: {integrity: sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==}
+  '@inquirer/type@3.0.6':
+    resolution: {integrity: sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -717,20 +717,23 @@ packages:
     resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
     engines: {node: '>= 18'}
 
-  '@octokit/core@6.1.4':
-    resolution: {integrity: sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==}
+  '@octokit/core@6.1.5':
+    resolution: {integrity: sha512-vvmsN0r7rguA+FySiCsbaTTobSftpIDIpPW81trAmsv9TGxg3YCujAxRYp/Uy8xmDgYCzzgulG62H7KYUFmeIg==}
     engines: {node: '>= 18'}
 
-  '@octokit/endpoint@10.1.3':
-    resolution: {integrity: sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==}
+  '@octokit/endpoint@10.1.4':
+    resolution: {integrity: sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==}
     engines: {node: '>= 18'}
 
-  '@octokit/graphql@8.2.1':
-    resolution: {integrity: sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==}
+  '@octokit/graphql@8.2.2':
+    resolution: {integrity: sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==}
     engines: {node: '>= 18'}
 
   '@octokit/openapi-types@24.2.0':
     resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/openapi-types@25.0.0':
+    resolution: {integrity: sha512-FZvktFu7HfOIJf2BScLKIEYjDsw6RKc7rBJCdvCTfKsVnx2GEB/Nbzjr29DUdb7vQhlzS/j8qDzdditP0OC6aw==}
 
   '@octokit/plugin-paginate-rest@11.6.0':
     resolution: {integrity: sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==}
@@ -750,12 +753,12 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/request-error@6.1.7':
-    resolution: {integrity: sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==}
+  '@octokit/request-error@6.1.8':
+    resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
     engines: {node: '>= 18'}
 
-  '@octokit/request@9.2.2':
-    resolution: {integrity: sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==}
+  '@octokit/request@9.2.3':
+    resolution: {integrity: sha512-Ma+pZU8PXLOEYzsWf0cn/gY+ME57Wq8f49WTXA8FMHp2Ps9djKw//xYJ1je8Hm0pR2lU9FUGeJRWOtxq6olt4w==}
     engines: {node: '>= 18'}
 
   '@octokit/rest@21.1.1':
@@ -764,6 +767,9 @@ packages:
 
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.0.0':
+    resolution: {integrity: sha512-VVmZP0lEhbo2O1pdq63gZFiGCKkm8PPp8AUOijlwPO6hojEVjspA0MWKP7E4hbvGxzFKNqKr6p0IYtOH/Wf/zA==}
 
   '@oxc-resolver/binding-darwin-arm64@5.0.0':
     resolution: {integrity: sha512-zwHAf+owoxSWTDD4dFuwW+FkpaDzbaL30H5Ltocb+RmLyg4WKuteusRLKh5Y8b/cyu7UzhxM0haIqQjyqA1iuA==}
@@ -1419,8 +1425,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.2.5:
-    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
+  vite@6.2.6:
+    resolution: {integrity: sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -1605,27 +1611,27 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@inquirer/checkbox@4.1.4(@types/node@22.14.0)':
+  '@inquirer/checkbox@4.1.5(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/confirm@5.1.8(@types/node@22.14.0)':
+  '@inquirer/confirm@5.1.9(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/core@10.1.9(@types/node@22.14.0)':
+  '@inquirer/core@10.1.10(@types/node@22.14.0)':
     dependencies:
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -1635,89 +1641,89 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/editor@4.2.9(@types/node@22.14.0)':
+  '@inquirer/editor@4.2.10(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       external-editor: 3.1.0
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/expand@4.0.11(@types/node@22.14.0)':
+  '@inquirer/expand@4.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
   '@inquirer/figures@1.0.11': {}
 
-  '@inquirer/input@4.1.8(@types/node@22.14.0)':
+  '@inquirer/input@4.1.9(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/number@3.0.11(@types/node@22.14.0)':
+  '@inquirer/number@3.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/password@4.0.11(@types/node@22.14.0)':
+  '@inquirer/password@4.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/prompts@7.4.0(@types/node@22.14.0)':
+  '@inquirer/prompts@7.4.1(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/checkbox': 4.1.4(@types/node@22.14.0)
-      '@inquirer/confirm': 5.1.8(@types/node@22.14.0)
-      '@inquirer/editor': 4.2.9(@types/node@22.14.0)
-      '@inquirer/expand': 4.0.11(@types/node@22.14.0)
-      '@inquirer/input': 4.1.8(@types/node@22.14.0)
-      '@inquirer/number': 3.0.11(@types/node@22.14.0)
-      '@inquirer/password': 4.0.11(@types/node@22.14.0)
-      '@inquirer/rawlist': 4.0.11(@types/node@22.14.0)
-      '@inquirer/search': 3.0.11(@types/node@22.14.0)
-      '@inquirer/select': 4.1.0(@types/node@22.14.0)
+      '@inquirer/checkbox': 4.1.5(@types/node@22.14.0)
+      '@inquirer/confirm': 5.1.9(@types/node@22.14.0)
+      '@inquirer/editor': 4.2.10(@types/node@22.14.0)
+      '@inquirer/expand': 4.0.12(@types/node@22.14.0)
+      '@inquirer/input': 4.1.9(@types/node@22.14.0)
+      '@inquirer/number': 3.0.12(@types/node@22.14.0)
+      '@inquirer/password': 4.0.12(@types/node@22.14.0)
+      '@inquirer/rawlist': 4.0.12(@types/node@22.14.0)
+      '@inquirer/search': 3.0.12(@types/node@22.14.0)
+      '@inquirer/select': 4.1.1(@types/node@22.14.0)
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/rawlist@4.0.11(@types/node@22.14.0)':
+  '@inquirer/rawlist@4.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/search@3.0.11(@types/node@22.14.0)':
+  '@inquirer/search@3.0.12(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/select@4.1.0(@types/node@22.14.0)':
+  '@inquirer/select@4.1.1(@types/node@22.14.0)':
     dependencies:
-      '@inquirer/core': 10.1.9(@types/node@22.14.0)
+      '@inquirer/core': 10.1.10(@types/node@22.14.0)
       '@inquirer/figures': 1.0.11
-      '@inquirer/type': 3.0.5(@types/node@22.14.0)
+      '@inquirer/type': 3.0.6(@types/node@22.14.0)
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
       '@types/node': 22.14.0
 
-  '@inquirer/type@3.0.5(@types/node@22.14.0)':
+  '@inquirer/type@3.0.6(@types/node@22.14.0)':
     optionalDependencies:
       '@types/node': 22.14.0
 
@@ -1725,7 +1731,7 @@ snapshots:
 
   '@napi-rs/cli@3.0.0-alpha.77(@emnapi/runtime@1.4.0)(@types/node@22.14.0)(emnapi@1.4.0)':
     dependencies:
-      '@inquirer/prompts': 7.4.0(@types/node@22.14.0)
+      '@inquirer/prompts': 7.4.1(@types/node@22.14.0)
       '@napi-rs/cross-toolchain': 0.0.19
       '@napi-rs/wasm-tools': 0.0.3
       '@octokit/rest': 21.1.1
@@ -1966,65 +1972,71 @@ snapshots:
 
   '@octokit/auth-token@5.1.2': {}
 
-  '@octokit/core@6.1.4':
+  '@octokit/core@6.1.5':
     dependencies:
       '@octokit/auth-token': 5.1.2
-      '@octokit/graphql': 8.2.1
-      '@octokit/request': 9.2.2
-      '@octokit/request-error': 6.1.7
-      '@octokit/types': 13.10.0
+      '@octokit/graphql': 8.2.2
+      '@octokit/request': 9.2.3
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.0.0
       before-after-hook: 3.0.2
       universal-user-agent: 7.0.2
 
-  '@octokit/endpoint@10.1.3':
+  '@octokit/endpoint@10.1.4':
     dependencies:
-      '@octokit/types': 13.10.0
+      '@octokit/types': 14.0.0
       universal-user-agent: 7.0.2
 
-  '@octokit/graphql@8.2.1':
+  '@octokit/graphql@8.2.2':
     dependencies:
-      '@octokit/request': 9.2.2
-      '@octokit/types': 13.10.0
+      '@octokit/request': 9.2.3
+      '@octokit/types': 14.0.0
       universal-user-agent: 7.0.2
 
   '@octokit/openapi-types@24.2.0': {}
 
-  '@octokit/plugin-paginate-rest@11.6.0(@octokit/core@6.1.4)':
+  '@octokit/openapi-types@25.0.0': {}
+
+  '@octokit/plugin-paginate-rest@11.6.0(@octokit/core@6.1.5)':
     dependencies:
-      '@octokit/core': 6.1.4
+      '@octokit/core': 6.1.5
       '@octokit/types': 13.10.0
 
-  '@octokit/plugin-request-log@5.3.1(@octokit/core@6.1.4)':
+  '@octokit/plugin-request-log@5.3.1(@octokit/core@6.1.5)':
     dependencies:
-      '@octokit/core': 6.1.4
+      '@octokit/core': 6.1.5
 
-  '@octokit/plugin-rest-endpoint-methods@13.5.0(@octokit/core@6.1.4)':
+  '@octokit/plugin-rest-endpoint-methods@13.5.0(@octokit/core@6.1.5)':
     dependencies:
-      '@octokit/core': 6.1.4
+      '@octokit/core': 6.1.5
       '@octokit/types': 13.10.0
 
-  '@octokit/request-error@6.1.7':
+  '@octokit/request-error@6.1.8':
     dependencies:
-      '@octokit/types': 13.10.0
+      '@octokit/types': 14.0.0
 
-  '@octokit/request@9.2.2':
+  '@octokit/request@9.2.3':
     dependencies:
-      '@octokit/endpoint': 10.1.3
-      '@octokit/request-error': 6.1.7
-      '@octokit/types': 13.10.0
+      '@octokit/endpoint': 10.1.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.0.0
       fast-content-type-parse: 2.0.1
       universal-user-agent: 7.0.2
 
   '@octokit/rest@21.1.1':
     dependencies:
-      '@octokit/core': 6.1.4
-      '@octokit/plugin-paginate-rest': 11.6.0(@octokit/core@6.1.4)
-      '@octokit/plugin-request-log': 5.3.1(@octokit/core@6.1.4)
-      '@octokit/plugin-rest-endpoint-methods': 13.5.0(@octokit/core@6.1.4)
+      '@octokit/core': 6.1.5
+      '@octokit/plugin-paginate-rest': 11.6.0(@octokit/core@6.1.5)
+      '@octokit/plugin-request-log': 5.3.1(@octokit/core@6.1.5)
+      '@octokit/plugin-rest-endpoint-methods': 13.5.0(@octokit/core@6.1.5)
 
   '@octokit/types@13.10.0':
     dependencies:
       '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.0.0':
+    dependencies:
+      '@octokit/openapi-types': 25.0.0
 
   '@oxc-resolver/binding-darwin-arm64@5.0.0':
     optional: true
@@ -2142,13 +2154,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.2.5(@types/node@22.14.0))':
+  '@vitest/mocker@3.1.1(vite@6.2.6(@types/node@22.14.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -2595,7 +2607,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2610,7 +2622,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.5(@types/node@22.14.0):
+  vite@6.2.6(@types/node@22.14.0):
     dependencies:
       esbuild: 0.25.2
       postcss: 8.5.3
@@ -2622,7 +2634,7 @@ snapshots:
   vitest@3.1.1(@types/node@22.14.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@22.14.0))
+      '@vitest/mocker': 3.1.1(vite@6.2.6(@types/node@22.14.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -2638,7 +2650,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
       vite-node: 3.1.1(@types/node@22.14.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -189,8 +189,7 @@ impl<Fs: FileSystem> Cache for FsCache<Fs> {
                 )
             })?;
         callback(&mut tsconfig)?;
-        tsconfig.expand_template_variables();
-        let tsconfig = Arc::new(tsconfig);
+        let tsconfig = Arc::new(tsconfig.build());
         tsconfigs.insert(path.to_path_buf(), Arc::clone(&tsconfig));
         Ok(tsconfig)
     }

--- a/src/tests/tsconfig_paths.rs
+++ b/src/tests/tsconfig_paths.rs
@@ -11,12 +11,12 @@ use crate::{
 
 // <https://github.com/parcel-bundler/parcel/blob/b6224fd519f95e68d8b93ba90376fd94c8b76e69/packages/utils/node-resolver-rs/src/lib.rs#L2303>
 #[test]
-fn tsconfig() {
+fn tsconfig_resolve() {
     let f = super::fixture_root().join("tsconfig");
 
     #[rustfmt::skip]
     let pass = [
-        (f.clone(), None, "ts-path", f.join("foo.js")),
+        (f.clone(), None, "ts-path", f.join("src/foo.js")),
         (f.join("nested"), None, "ts-path", f.join("nested/test.js")),
         (f.join("cases/index"), None, "foo", f.join("node_modules/tsconfig-index/foo.js")),
         // This requires reading package.json.tsconfig field
@@ -45,7 +45,7 @@ fn tsconfig() {
 
     #[rustfmt::skip]
     let data = [
-        (f.join("node_modules/tsconfig-not-used"), "ts-path", Ok(f.join("foo.js"))),
+        (f.join("node_modules/tsconfig-not-used"), "ts-path", Ok(f.join("src/foo.js"))),
     ];
 
     let resolver = Resolver::new(ResolveOptions {
@@ -133,7 +133,7 @@ fn test_paths() {
         }
     })
     .to_string();
-    let tsconfig = TsConfigSerde::parse(true, path, &mut tsconfig_json).unwrap();
+    let tsconfig = TsConfigSerde::parse(true, path, &mut tsconfig_json).unwrap().build();
 
     let data = [
         ("jquery", vec!["/foo/node_modules/jquery/dist/jquery"]),
@@ -163,7 +163,7 @@ fn test_base_url() {
         }
     })
     .to_string();
-    let tsconfig = TsConfigSerde::parse(true, path, &mut tsconfig_json).unwrap();
+    let tsconfig = TsConfigSerde::parse(true, path, &mut tsconfig_json).unwrap().build();
 
     let data = [
         ("foo", vec!["/foo/src/foo"]),
@@ -194,7 +194,7 @@ fn test_paths_and_base_url() {
         }
     })
     .to_string();
-    let tsconfig = TsConfigSerde::parse(true, path, &mut tsconfig_json).unwrap();
+    let tsconfig = TsConfigSerde::parse(true, path, &mut tsconfig_json).unwrap().build();
 
     let data = [
         ("test", vec!["/foo/src/generated/test", "/foo/src/test"]),
@@ -247,9 +247,17 @@ fn test_template_variable() {
 
     #[rustfmt::skip]
     let pass = [
-        (f2.clone(), "tsconfig1.json", "foo", f2.join("foo.js")),
-        (f2.clone(), "tsconfig2.json", "foo", f2.join("foo.js")),
-        (f.clone(), "tsconfig_template_variable.json", "foo", f.join("foo.js")),
+        (f2.clone(), "tsconfig.json", "foo", f2.join("src/foo.js")),
+        (f2.clone(), "tsconfig_base_url1.json", "@/foo", f2.join("src/foo.js")),
+        (f2.clone(), "tsconfig_base_url2.json", "@/foo", f2.join("src/foo.js")),
+        (f2.clone(), "tsconfig_extends1.json", "foo", f2.join("src/foo.js")),
+        (f2.clone(), "tsconfig_extends2.json", "foo", f2.join("src/foo.js")),
+        (f2.clone(), "tsconfig_extends3.json", "foo", f2.join("src/foo.js")),
+        (f2.clone(), "tsconfig_extends4.json", "foo", f2.join("src/foo.js")),
+        (f.clone(), "tsconfig_template_variable1.json", "foo", f.join("src/foo.js")),
+        (f.clone(), "tsconfig_template_variable2.json", "foo", f.join("src/foo.js")),
+        (f.clone(), "tsconfig_template_variable3.json", "foo", f.join("src/foo.js")),
+        (f.clone(), "tsconfig_template_variable4.json", "foo", f.join("src/foo.js")),
     ];
 
     for (dir, tsconfig, request, expected) in pass {

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -39,7 +39,7 @@ fn auto() {
         // Template variable
         {
             let dir = f.parent().unwrap().join("paths_template_variable");
-            (dir.clone(), "foo", dir.join("foo.js"))
+            (dir.clone(), "foo", dir.join("src/foo.js"))
         }
     ];
 
@@ -62,7 +62,7 @@ fn auto() {
         // Template variable
         {
             let dir = f.parent().unwrap().join("paths_template_variable");
-            (dir.clone(), "foo", Ok(dir.join("foo.js")))
+            (dir.clone(), "foo", Ok(dir.join("src/foo.js")))
         }
     ];
 

--- a/src/tsconfig.rs
+++ b/src/tsconfig.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Debug,
     hash::BuildHasherDefault,
     path::{Path, PathBuf},
     sync::Arc,
@@ -9,6 +10,8 @@ use rustc_hash::FxHasher;
 
 use crate::{TsconfigReferences, path::PathUtil};
 
+const TEMPLATE_VARIABLE: &str = "${configDir}";
+
 pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefault<FxHasher>>;
 
 /// Abstract representation for the contents of a `tsconfig.json` file, as well
@@ -17,8 +20,8 @@ pub type CompilerOptionsPathsMap = IndexMap<String, Vec<String>, BuildHasherDefa
 /// This representation makes no assumptions regarding how the file was
 /// deserialized.
 #[allow(clippy::missing_errors_doc)] // trait impls should be free to return any typesafe error
-pub trait TsConfig: Sized {
-    type Co: CompilerOptions;
+pub trait TsConfig: Sized + Debug {
+    type Co: CompilerOptions + Debug;
 
     /// Whether this is the caller tsconfig.
     /// Used for final template variable substitution when all configs are extended and merged.
@@ -74,35 +77,22 @@ pub trait TsConfig: Sized {
         self.compiler_options().base_url().unwrap_or_else(|| self.directory())
     }
 
-    /// Expands all template variables in this tsconfig.
-    fn expand_template_variables(&mut self) {
-        if self.root() {
-            let dir = self.directory().to_path_buf();
-            // Substitute template variable in `tsconfig.compilerOptions.paths`
-            if let Some(paths) = &mut self.compiler_options_mut().paths_mut() {
-                for paths in paths.values_mut() {
-                    for path in paths {
-                        Self::substitute_template_variable(&dir, path);
-                    }
-                }
-            }
-        }
-    }
-
     /// Inherits settings from the given tsconfig into `self`.
     fn extend_tsconfig(&mut self, tsconfig: &Self) {
         let compiler_options = self.compiler_options_mut();
-        if compiler_options.paths().is_none() {
-            compiler_options.set_paths_base(compiler_options.base_url().map_or_else(
-                || tsconfig.compiler_options().paths_base().to_path_buf(),
-                Path::to_path_buf,
-            ));
-            compiler_options.set_paths(tsconfig.compiler_options().paths().cloned());
-        }
+
         if compiler_options.base_url().is_none() {
             if let Some(base_url) = tsconfig.compiler_options().base_url() {
                 compiler_options.set_base_url(base_url.to_path_buf());
             }
+        }
+
+        if compiler_options.paths().is_none() {
+            let paths_base = compiler_options
+                .base_url()
+                .map_or_else(|| tsconfig.directory().to_path_buf(), Path::to_path_buf);
+            compiler_options.set_paths_base(paths_base);
+            compiler_options.set_paths(tsconfig.compiler_options().paths().cloned());
         }
 
         if compiler_options.experimental_decorators().is_none() {
@@ -135,6 +125,65 @@ pub trait TsConfig: Sized {
             if let Some(jsx_import_source) = tsconfig.compiler_options().jsx_import_source() {
                 compiler_options.set_jsx_import_source(jsx_import_source.to_string());
             }
+        }
+    }
+
+    /// "Build" the root tsconfig, resolve:
+    ///
+    /// * `{configDir}` template variable
+    /// * `paths_base` for resolving paths alias
+    /// * `baseUrl` to absolute path
+    #[must_use]
+    fn build(mut self) -> Self {
+        // Only the root tsconfig requires paths resolution.
+        if !self.root() {
+            return self;
+        }
+
+        let config_dir = self.directory().to_path_buf();
+
+        if let Some(base_url) = self.compiler_options().base_url() {
+            // Substitute template variable in `tsconfig.compilerOptions.baseUrl`.
+            let base_url = base_url.to_string_lossy().strip_prefix(TEMPLATE_VARIABLE).map_or_else(
+                || config_dir.normalize_with(base_url),
+                |stripped_path| config_dir.join(stripped_path.trim_start_matches('/')),
+            );
+            self.compiler_options_mut().set_base_url(base_url);
+        }
+
+        if self.compiler_options().paths().is_some() {
+            // `bases_base` should use config dir if it is not resolved with base url nor extended
+            // with another tsconfig.
+            if let Some(base_url) = self.compiler_options().base_url().map(Path::to_path_buf) {
+                self.compiler_options_mut().set_paths_base(base_url);
+            }
+
+            if self.compiler_options().paths_base().as_os_str().is_empty() {
+                self.compiler_options_mut().set_paths_base(config_dir.clone());
+            }
+
+            // Substitute template variable in `tsconfig.compilerOptions.paths`.
+            for paths in self.compiler_options_mut().paths_mut().unwrap().values_mut() {
+                for path in paths {
+                    Self::substitute_template_variable(&config_dir, path);
+                }
+            }
+        }
+
+        self
+    }
+
+    /// Template variable `${configDir}` for substitution of config files
+    /// directory path.
+    ///
+    /// NOTE: All tests cases are just a head replacement of `${configDir}`, so
+    ///       we are constrained as such.
+    ///
+    /// See <https://github.com/microsoft/TypeScript/pull/58042>.
+    fn substitute_template_variable(directory: &Path, path: &mut String) {
+        if let Some(stripped_path) = path.strip_prefix(TEMPLATE_VARIABLE) {
+            *path =
+                directory.join(stripped_path.trim_start_matches('/')).to_string_lossy().to_string();
         }
     }
 
@@ -214,20 +263,6 @@ pub trait TsConfig: Sized {
             .map(|p| compiler_options.paths_base().normalize_with(p))
             .chain(base_url_iter)
             .collect()
-    }
-
-    /// Template variable `${configDir}` for substitution of config files
-    /// directory path.
-    ///
-    /// NOTE: All tests cases are just a head replacement of `${configDir}`, so
-    ///       we are constrained as such.
-    ///
-    /// See <https://github.com/microsoft/TypeScript/pull/58042>.
-    fn substitute_template_variable(directory: &Path, path: &mut String) {
-        const TEMPLATE_VARIABLE: &str = "${configDir}/";
-        if let Some(stripped_path) = path.strip_prefix(TEMPLATE_VARIABLE) {
-            *path = directory.join(stripped_path).to_string_lossy().to_string();
-        }
     }
 }
 

--- a/src/tsconfig_serde.rs
+++ b/src/tsconfig_serde.rs
@@ -6,8 +6,7 @@ use std::{
 use serde::Deserialize;
 
 use crate::{
-    CompilerOptions, CompilerOptionsPathsMap, PathUtil, ProjectReference, TsConfig,
-    TsconfigReferences,
+    CompilerOptions, CompilerOptionsPathsMap, ProjectReference, TsConfig, TsconfigReferences,
 };
 
 #[derive(Debug, Deserialize)]
@@ -265,14 +264,6 @@ impl TsConfigSerde {
         let mut tsconfig: Self = serde_json::from_str(json)?;
         tsconfig.root = root;
         tsconfig.path = path.to_path_buf();
-        let directory = tsconfig.directory().to_path_buf();
-        if let Some(base_url) = tsconfig.compiler_options.base_url {
-            tsconfig.compiler_options.base_url = Some(directory.normalize_with(base_url));
-        }
-        if tsconfig.compiler_options.paths.is_some() {
-            tsconfig.compiler_options.paths_base =
-                tsconfig.compiler_options.base_url.as_ref().map_or(directory, Clone::clone);
-        }
         Ok(tsconfig)
     }
 }


### PR DESCRIPTION
close #30
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Merge upstream changes from `oxc-project/oxc-resolver`, updating workflows, dependencies, and handling of `${configDir}` in `tsconfig`.
> 
>   - **Workflows**:
>     - Add `riscv64gc-unknown-linux-gnu` target to `release-napi.yml`.
>     - Update `release-plz-action` version in `release-plz.yml` to `v0.5.102`.
>   - **Dependencies**:
>     - Update `cc` to `1.2.18`, `codspeed` to `2.10.0`, `iana-time-zone` to `0.1.63`, `redox_syscall` to `0.5.11`, `smallvec` to `1.15.0`, and `windows-core` to `0.61.0` in `Cargo.lock`.
>   - **Template Variables**:
>     - Implement `${configDir}` substitution in `tsconfig.rs` and `tsconfig_serde.rs`.
>     - Add new test cases for `${configDir}` in `tsconfig_paths.rs` and `tsconfig_project_references.rs`.
>   - **File Changes**:
>     - Rename `foo.js` to `src/foo.js` in `fixtures/tsconfig` and update related paths in test cases.
>     - Remove `package.metadata.cargo-machete` from `napi/Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for fced7931b47494aa62d1a010b2a3200f36e90678. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for building for the RISC-V architecture.
- **Bug Fixes**
	- Enforced stricter checks during artifact uploads to catch missing files.
- **Refactor**
	- Streamlined configuration for module resolution with updated source paths.
	- Improved the build process for clearer, more reliable setup.
- **Tests**
	- Adjusted test expectations to align with the updated directory structure.
- **Chores**
	- Upgraded workflow actions and package dependencies for better tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->