### PR TITLE
fix: disable mimalloc on linux with aarch64

### DIFF
--- a/napi/src/lib.rs
+++ b/napi/src/lib.rs
@@ -1,4 +1,10 @@
-#[cfg(all(not(target_arch = "arm"), not(target_os = "freebsd"), not(target_family = "wasm")))]
+// Disable mimalloc on ARM, FreeBSD, WASM, and Linux/aarch64 due to known allocator issues (see #64).
+#[cfg(not(any(
+    target_arch = "arm",
+    target_os = "freebsd",
+    target_family = "wasm",
+    all(target_os = "linux", target_arch = "aarch64")
+)))]
 #[global_allocator]
 static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 


### PR DESCRIPTION
close #64
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable `mimalloc` on Linux with `aarch64` in `napi/src/lib.rs` due to allocator issues.
> 
>   - **Configuration**:
>     - Disable `mimalloc` on Linux with `aarch64` architecture in `napi/src/lib.rs` due to allocator issues (see #64).
>     - Existing exclusions for ARM, FreeBSD, and WASM remain unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 10f555d3e16ffb0b6c98ded496620bf7b5d43001. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated internal configuration to improve compatibility on certain Linux devices. No visible changes to app features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->