### PR TITLE
test: add case for import-js/eslint-import-resolver-typescript#429

### DIFF
--- a/src/specifier.rs
+++ b/src/specifier.rs
@@ -22,14 +22,14 @@ impl<'a> Specifier<'a> {
             b'/' | b'.' | b'#' => 1,
             _ => 0,
         };
-        let (path, query, fragment) = Self::parse_query_framgment(specifier, offset);
+        let (path, query, fragment) = Self::parse_query_fragment(specifier, offset);
         if path.is_empty() {
             return Err(SpecifierError::Empty(specifier.to_string()));
         }
         Ok(Self { path, query, fragment })
     }
 
-    fn parse_query_framgment(
+    fn parse_query_fragment(
         specifier: &'a str,
         skip: usize,
     ) -> (Cow<'a, str>, Option<&'a str>, Option<&'a str>) {

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -89,12 +89,16 @@ fn multi_dot_extension() {
     let resolver = Resolver::new(ResolveOptions {
         // Test for `.d.ts`, not part of enhanced-resolve.
         extensions: vec![".a.b.c".into(), ".d.ts".into(), ".ts".into(), ".js".into()],
+        extension_alias: vec![
+            (".ts".into(), vec![".ts".into(), ".d.ts".into()]),
+        ],
         ..ResolveOptions::default()
     });
 
     #[rustfmt::skip]
     let pass = [
         ("should resolve according to order of provided extensions", "./foo", "foo.ts"),
+        ("should resolve .d.ts for .ts", "./bar.ts", "bar.d.ts"),
         ("should resolve file with extension", "./app.module", "app.module.js")
     ];
 

--- a/src/tests/extensions.rs
+++ b/src/tests/extensions.rs
@@ -89,9 +89,7 @@ fn multi_dot_extension() {
     let resolver = Resolver::new(ResolveOptions {
         // Test for `.d.ts`, not part of enhanced-resolve.
         extensions: vec![".a.b.c".into(), ".d.ts".into(), ".ts".into(), ".js".into()],
-        extension_alias: vec![
-            (".ts".into(), vec![".ts".into(), ".d.ts".into()]),
-        ],
+        extension_alias: vec![(".ts".into(), vec![".ts".into(), ".d.ts".into()])],
         ..ResolveOptions::default()
     });
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that requests for `.ts` files correctly resolve to `.d.ts` files, enhancing coverage of file extension resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add test for `.ts` to `.d.ts` resolution and fix typo in `parse_query_fragment()` function name.
> 
>   - **Tests**:
>     - Added test in `extensions.rs` to verify `.ts` files resolve to `.d.ts` files.
>   - **Fixes**:
>     - Corrected typo in `parse_query_fragment()` function name in `specifier.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for de1967727e40eec073731f79414d1ba0abff693f. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->