### PR TITLE
fix: rework on handling DOS device paths on Windows

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,7 @@ pub enum ResolveError {
     #[error("{0}")]
     IOError(IOError),
 
+    /// Indicates the resulting path won't be able consumable by NodeJS `import` or `require`.
     /// For example, DOS device path with Volume GUID (`\\?\Volume{...}`) is not supported.
     #[error("Path {0:?} contains unsupported construct.")]
     PathNotSupported(PathBuf),

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ pub enum ResolveError {
     #[error("{0}")]
     IOError(IOError),
 
-    /// For example, Windows UNC path with Volume GUID is not supported.
+    /// For example, DOS device path with Volume GUID (`\\?\Volume{...}`) is not supported.
     #[error("Path {0:?} contains unsupported construct.")]
     PathNotSupported(PathBuf),
 

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -7,6 +7,8 @@ use cfg_if::cfg_if;
 #[cfg(feature = "yarn_pnp")]
 use pnp::fs::{LruZipCache, VPath, VPathInfo, ZipCache};
 
+use crate::ResolveError;
+
 /// File System abstraction used for `ResolverGeneric`
 pub trait FileSystem: Send + Sync {
     /// See [std::fs::read]
@@ -54,9 +56,13 @@ pub trait FileSystem: Send + Sync {
     /// Returns the resolution of a symbolic link.
     ///
     /// # Errors
+    /// * Returns an error of [`ResolveError::IOError`] kind if there is an IO error invoking [`std::fs::read_link`].
+    /// * Returns an error of [`ResolveError::PathNotSupported`] kind if the symlink target cannot be represented
+    /// as a path that can be consumed by the `import`/`require` syntax of Node.js.
+    /// Caller should not try to follow the symlink in this case.
     ///
     /// See [std::fs::read_link]
-    fn read_link(&self, path: &Path) -> io::Result<PathBuf>;
+    fn read_link(&self, path: &Path) -> Result<PathBuf, ResolveError>;
 
     /// See [std::fs::canonicalize]
     ///
@@ -186,15 +192,11 @@ impl FileSystemOs {
     ///
     /// See [std::fs::read_link]
     #[inline]
-    pub fn read_link(path: &Path) -> io::Result<PathBuf> {
+    pub fn read_link(path: &Path) -> Result<PathBuf, ResolveError> {
         let target = fs::read_link(path)?;
         cfg_if! {
             if #[cfg(target_os = "windows")] {
-                match crate::windows::try_strip_windows_prefix(path) {
-                    // We won't follow the link if we cannot represent its target properly.
-                    Ok(p) | Err(crate::ResolveError::PathNotSupported(p)) => Ok(p),
-                    _ => unreachable!(),
-                }
+                crate::windows::strip_windows_prefix(target)
             } else {
                 Ok(target.to_path_buf())
             }
@@ -258,7 +260,7 @@ impl FileSystem for FileSystemOs {
         Self::symlink_metadata(path)
     }
 
-    fn read_link(&self, path: &Path) -> io::Result<PathBuf> {
+    fn read_link(&self, path: &Path) -> Result<PathBuf, ResolveError> {
         cfg_if! {
             if #[cfg(feature = "yarn_pnp")] {
                 match VPath::from(path)? {
@@ -267,7 +269,7 @@ impl FileSystem for FileSystemOs {
                     VPath::Native(path) => Self::read_link(&path),
                 }
             } else {
-                Self::read_link(path)
+                Self::try_read_link(path)
             }
         }
     }
@@ -336,38 +338,4 @@ fn metadata() {
         "FileMetadata { is_file: true, is_dir: true, is_symlink: true }"
     );
     let _ = meta;
-}
-
-#[test]
-fn test_strip_windows_prefix() {
-    assert_eq!(
-        FileSystemOs::try_strip_windows_prefix(PathBuf::from(
-            r"\\?\C:\Users\user\Documents\file.txt"
-        )),
-        Some(PathBuf::from(r"C:\Users\user\Documents\file.txt"))
-    );
-
-    assert_eq!(
-        FileSystemOs::try_strip_windows_prefix(PathBuf::from(
-            r"\\.\C:\Users\user\Documents\file.txt"
-        )),
-        Some(PathBuf::from(r"C:\Users\user\Documents\file.txt"))
-    );
-
-    assert_eq!(
-        FileSystemOs::try_strip_windows_prefix(PathBuf::from(r"\\?\UNC\server\share\file.txt")),
-        Some(PathBuf::from(r"\\server\share\file.txt"))
-    );
-
-    assert_eq!(
-        FileSystemOs::try_strip_windows_prefix(PathBuf::from(
-            r"\\?\Volume{c8ec34d8-3ba6-45c3-9b9d-3e4148e12d00}\file.txt"
-        )),
-        None
-    );
-
-    assert_eq!(
-        FileSystemOs::try_strip_windows_prefix(PathBuf::from(r"\\?\BootPartition\file.txt")),
-        None
-    );
 }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -193,12 +193,12 @@ impl FileSystemOs {
     /// See [std::fs::read_link]
     #[inline]
     pub fn read_link(path: &Path) -> Result<PathBuf, ResolveError> {
-        let target = fs::read_link(path)?;
+        let path = fs::read_link(path)?;
         cfg_if! {
             if #[cfg(target_os = "windows")] {
-                crate::windows::strip_windows_prefix(target)
+                crate::windows::strip_windows_prefix(path)
             } else {
-                Ok(target.to_path_buf())
+                Ok(path)
             }
         }
     }

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -58,8 +58,8 @@ pub trait FileSystem: Send + Sync {
     /// # Errors
     /// * Returns an error of [`ResolveError::IOError`] kind if there is an IO error invoking [`std::fs::read_link`].
     /// * Returns an error of [`ResolveError::PathNotSupported`] kind if the symlink target cannot be represented
-    /// as a path that can be consumed by the `import`/`require` syntax of Node.js.
-    /// Caller should not try to follow the symlink in this case.
+    ///   as a path that can be consumed by the `import`/`require` syntax of Node.js.
+    ///   Caller should not try to follow the symlink in this case.
     ///
     /// See [std::fs::read_link]
     fn read_link(&self, path: &Path) -> Result<PathBuf, ResolveError>;

--- a/src/options.rs
+++ b/src/options.rs
@@ -157,17 +157,17 @@ pub struct ResolveOptions {
     /// Even if this option has been enabled, the resolver may decide not to follow the symlinks if the target cannot be
     /// represented as a valid path for `require` or `import` statements in NodeJS. Specifically, we won't follow the symlink if:
     /// 1. On Windows, the symlink is a [Volume mount point](https://learn.microsoft.com/en-us/windows/win32/fileio/volume-mount-points)
-    ///     to a Volume that does not have a drive letter.
-    ///     See: How to [mount a drive in a folder](https://learn.microsoft.com/en-us/windows-server/storage/disk-management/assign-a-mount-point-folder-path-to-a-drive).
+    ///    to a Volume that does not have a drive letter.
+    ///    See: How to [mount a drive in a folder](https://learn.microsoft.com/en-us/windows-server/storage/disk-management/assign-a-mount-point-folder-path-to-a-drive).
     /// 2. On Windows, the symlink points to a [DOS device path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths)
-    ///     that cannot be reduced into a [traditional DOS path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#traditional-dos-paths).
-    ///     For example, all of the following symlink targets _will not_ be followed:
-    ///     * `\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\folder\` (Volume GUID)
-    ///     * `\\.\BootPartition\folder\file.ts` (Drive name)
+    ///    that cannot be reduced into a [traditional DOS path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#traditional-dos-paths).
+    ///    For example, all of the following symlink targets _will not_ be followed:
+    ///    * `\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\folder\` (Volume GUID)
+    ///    * `\\.\BootPartition\folder\file.ts` (Drive name)
     ///
-    ///     DOS device path either pointing to a drive with driver letter, or a UNC path, will be simplified and followed, such as
-    ///     * `\\.\D:\path\to\file`: reduced to `D:\path\to\file`;
-    ///     * `\\.\UNC\server\share\path\to\file`: reduced to `\\server\share\path\to\file`.
+    ///    DOS device path either pointing to a drive with driver letter, or a UNC path, will be simplified and followed, such as
+    ///    * `\\.\D:\path\to\file`: reduced to `D:\path\to\file`;
+    ///    * `\\.\UNC\server\share\path\to\file`: reduced to `\\server\share\path\to\file`.
     ///
     /// Default `true`
     pub symlinks: bool,

--- a/src/options.rs
+++ b/src/options.rs
@@ -150,9 +150,24 @@ pub struct ResolveOptions {
     /// Default `[]`
     pub roots: Vec<PathBuf>,
 
-    /// Whether to resolve symlinks to their symlinked location.
+    /// Whether to resolve symlinks to their symlinked location, if possible.
     /// When enabled, symlinked resources are resolved to their real path, not their symlinked location.
-    /// Note that this may cause module resolution to fail when using tools that symlink packages (like npm link).
+    /// Note that this may cause module resolution to fail when using tools that symlink packages (like `npm link`).
+    ///
+    /// Even if this option has been enabled, the resolver may decide not to follow the symlinks if the target cannot be
+    /// represented as a valid path for `require` or `import` statements in NodeJS. Specifically, we won't follow the symlink if:
+    /// 1. On Windows, the symlink is a [Volume mount point](https://learn.microsoft.com/en-us/windows/win32/fileio/volume-mount-points)
+    ///     to a Volume that does not have a drive letter.
+    ///     See: How to [mount a drive in a folder](https://learn.microsoft.com/en-us/windows-server/storage/disk-management/assign-a-mount-point-folder-path-to-a-drive).
+    /// 2. On Windows, the symlink points to a [DOS device path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths)
+    ///     that cannot be reduced into a [traditional DOS path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#traditional-dos-paths).
+    ///     For example, all of the following symlink targets _will not_ be followed:
+    ///     * `\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\folder\` (Volume GUID)
+    ///     * `\\.\BootPartition\folder\file.ts` (Drive name)
+    ///
+    ///     DOS device path either pointing to a drive with driver letter, or a UNC path, will be simplified and followed, such as
+    ///     * `\\.\D:\path\to\file`: reduced to `D:\path\to\file`;
+    ///     * `\\.\UNC\server\share\path\to\file`: reduced to `\\server\share\path\to\file`.
     ///
     /// Default `true`
     pub symlinks: bool,

--- a/src/options.rs
+++ b/src/options.rs
@@ -165,7 +165,7 @@ pub struct ResolveOptions {
     ///    * `\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\folder\` (Volume GUID)
     ///    * `\\.\BootPartition\folder\file.ts` (Drive name)
     ///
-    ///    DOS device path either pointing to a drive with driver letter, or a UNC path, will be simplified and followed, such as
+    ///    DOS device path either pointing to a drive with drive letter, or a UNC path, will be simplified and followed, such as
     ///    * `\\.\D:\path\to\file`: reduced to `D:\path\to\file`;
     ///    * `\\.\UNC\server\share\path\to\file`: reduced to `\\server\share\path\to\file`.
     ///

--- a/src/tests/memory_fs.rs
+++ b/src/tests/memory_fs.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{FileMetadata, FileSystem};
+use crate::{FileMetadata, FileSystem, ResolveError};
 
 #[derive(Default)]
 pub struct MemoryFS {
@@ -72,8 +72,8 @@ impl FileSystem for MemoryFS {
         self.metadata(path)
     }
 
-    fn read_link(&self, _path: &Path) -> io::Result<PathBuf> {
-        Err(io::Error::new(io::ErrorKind::NotFound, "not a symlink"))
+    fn read_link(&self, _path: &Path) -> Result<PathBuf, ResolveError> {
+        Err(io::Error::new(io::ErrorKind::NotFound, "not a symlink").into())
     }
 
     fn canonicalize(&self, _path: &Path) -> io::Result<PathBuf> {


### PR DESCRIPTION
This PR is cherry-picked from the first several iterations of oxc-project/oxc-resolver#455 and fixes #65

> 
> This PR changed the name and return type of `strip_windows_prefix` to `try_strip_windows_prefix`, allowing it to return `None` to indicate unsupported [DOS device paths](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths).
> 
> Most significantly, symlinks referring to a drive without drive letter, usually accessed via a mount point (Mounted Volume), should not be resolved at all, as nodejs `import`/`require` does not support such properly, as of Node 22.
> 
> This PR also rectified the [UNC path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#unc-paths) resolution to prepend the `"\\"` portion to the path.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves handling of Windows DOS device paths by updating `strip_windows_prefix` to `try_strip_windows_prefix`, returning `None` for unsupported paths, and updating related functions and tests.
> 
>   - **Behavior**:
>     - Renames `strip_windows_prefix` to `try_strip_windows_prefix` in `windows.rs`, changing return type to `Option<PathBuf>` to return `None` for unsupported DOS device paths.
>     - Updates `try_read_link` in `file_system.rs` and `fs_cache.rs` to handle `None` return value, avoiding symlink resolution for unsupported paths.
>     - Modifies `ResolveOptions` in `options.rs` to document behavior for symlinks pointing to unsupported paths.
>   - **Tests**:
>     - Adds tests in `windows.rs` to verify `try_strip_windows_prefix` returns `None` for unsupported paths and correct paths for supported ones.
>     - Updates `memory_fs.rs` to reflect changes in `try_read_link` behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for aa869cae065f21e1fd36028a12ebea6e401a555f. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of Windows-specific symlink targets by not following unsupported or unrepresentable paths, such as volume GUID and certain DOS device paths.
- **Documentation**
	- Clarified symlink resolution behavior on Windows, specifying when symlinks are not followed due to unsupported target paths.
	- Enhanced error documentation for unsupported Windows path prefixes during symlink resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->