### PR TITLE
feat: merge from upstream `oxc-project/oxc-resolver` - 4th

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### <!-- 1 -->Bug Fixes
+
+- properly handle DOS device paths in strip_windows_prefix ([#455](https://github.com/oxc-project/oxc-resolver/pull/455))
+
 ## [1.6.3](https://github.com/unrs/unrs-resolver/compare/v1.6.2...v1.6.3) - 2025-04-21
 
 ### <!-- 1 -->Bug Fixes

--- a/fixtures/pnpm-workspace/packages/lib/package.json
+++ b/fixtures/pnpm-workspace/packages/lib/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "react": "^19.0.0"
+    "react": "^19.1.0"
   }
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -48,6 +48,6 @@
     "postinstall": "napi-postinstall unrs-resolver check"
   },
   "dependencies": {
-    "napi-postinstall": "^0.1.1"
+    "napi-postinstall": "^0.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^22.14.1",
     "emnapi": "^1.4.3",
     "typescript": "^5.8.3",
-    "vitest": "^3.1.1"
+    "vitest": "^3.1.2"
   },
   "packageManager": "pnpm@10.8.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^3.1.1
-        version: 3.1.1(@types/node@22.14.1)
+        specifier: ^3.1.2
+        version: 3.1.2(@types/node@22.14.1)
 
   fixtures/pnpm:
     devDependencies:
@@ -69,14 +69,14 @@ importers:
   fixtures/pnpm-workspace/packages/lib:
     dependencies:
       react:
-        specifier: ^19.0.0
+        specifier: ^19.1.0
         version: 19.1.0
 
   npm:
     dependencies:
       napi-postinstall:
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.1.5
+        version: 0.1.5
 
 packages:
 
@@ -901,11 +901,11 @@ packages:
   '@types/stylis@4.2.5':
     resolution: {integrity: sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==}
 
-  '@vitest/expect@3.1.1':
-    resolution: {integrity: sha512-q/zjrW9lgynctNbwvFtQkGK9+vvHA5UzVi2V8APrp1C6fG6/MuYYkmlx4FubuqLycCeSdHD5aadWfua/Vr0EUA==}
+  '@vitest/expect@3.1.2':
+    resolution: {integrity: sha512-O8hJgr+zREopCAqWl3uCVaOdqJwZ9qaDwUP7vy3Xigad0phZe9APxKhPcDNqYYi0rX5oMvwJMSCAXY2afqeTSA==}
 
-  '@vitest/mocker@3.1.1':
-    resolution: {integrity: sha512-bmpJJm7Y7i9BBELlLuuM1J1Q6EQ6K5Ye4wcyOpOMXMcePYKSIYlpcrCm4l/O6ja4VJA5G2aMJiuZkZdnxlC3SA==}
+  '@vitest/mocker@3.1.2':
+    resolution: {integrity: sha512-kOtd6K2lc7SQ0mBqYv/wdGedlqPdM/B38paPY+OwJ1XiNi44w3Fpog82UfOibmHaV9Wod18A09I9SCKLyDMqgw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -915,20 +915,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.1.1':
-    resolution: {integrity: sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==}
+  '@vitest/pretty-format@3.1.2':
+    resolution: {integrity: sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==}
 
-  '@vitest/runner@3.1.1':
-    resolution: {integrity: sha512-X/d46qzJuEDO8ueyjtKfxffiXraPRfmYasoC4i5+mlLEJ10UvPb0XH5M9C3gWuxd7BAQhpK42cJgJtq53YnWVA==}
+  '@vitest/runner@3.1.2':
+    resolution: {integrity: sha512-bhLib9l4xb4sUMPXnThbnhX2Yi8OutBMA8Yahxa7yavQsFDtwY/jrUZwpKp2XH9DhRFJIeytlyGpXCqZ65nR+g==}
 
-  '@vitest/snapshot@3.1.1':
-    resolution: {integrity: sha512-bByMwaVWe/+1WDf9exFxWWgAixelSdiwo2p33tpqIlM14vW7PRV5ppayVXtfycqze4Qhtwag5sVhX400MLBOOw==}
+  '@vitest/snapshot@3.1.2':
+    resolution: {integrity: sha512-Q1qkpazSF/p4ApZg1vfZSQ5Yw6OCQxVMVrLjslbLFA1hMDrT2uxtqMaw8Tc/jy5DLka1sNs1Y7rBcftMiaSH/Q==}
 
-  '@vitest/spy@3.1.1':
-    resolution: {integrity: sha512-+EmrUOOXbKzLkTDwlsc/xrwOlPDXyVk3Z6P6K4oiCndxz7YLpp/0R0UsWVOKT0IXWjjBJuSMk6D27qipaupcvQ==}
+  '@vitest/spy@3.1.2':
+    resolution: {integrity: sha512-OEc5fSXMws6sHVe4kOFyDSj/+4MSwst0ib4un0DlcYgQvRuYQ0+M2HyqGaauUMnjq87tmUaMNDxKQx7wNfVqPA==}
 
-  '@vitest/utils@3.1.1':
-    resolution: {integrity: sha512-1XIjflyaU2k3HMArJ50bwSh3wKWPD6Q47wz/NUSmRV0zNywPc4w79ARjg/i/aNINHwA+mIALhUVqD9/aUvZNgg==}
+  '@vitest/utils@3.1.2':
+    resolution: {integrity: sha512-5GGd0ytZ7BH3H6JTj9Kw7Prn1Nbg0wZVrIvou+UWxm54d+WoXXgAgjFJ8wn3LdagWLFSEfpPeyYrByZaGEZHLg==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -1213,8 +1213,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-postinstall@0.1.1:
-    resolution: {integrity: sha512-TYY03NBTDA+gDLvOaVpir/Myk0bZhumlhmALLCqiH389wJIDVnF+jfCDS+Sw1m2qpyJ/hjyK0GDYgLov6Z1Pkg==}
+  napi-postinstall@0.1.5:
+    resolution: {integrity: sha512-HI5bHONOUYqV+FJvueOSgjRxHTLB25a3xIv59ugAxFe7xRNbW96hyYbMbsKzl+QvFV9mN/SrtHwiU+vYhMwA7Q==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
 
@@ -1383,8 +1383,8 @@ packages:
   universal-user-agent@7.0.2:
     resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
 
-  vite-node@3.1.1:
-    resolution: {integrity: sha512-V+IxPAE2FvXpTCHXyNem0M+gWm6J7eRyWPR6vYoG/Gl+IscNOjXzztUhimQgTxaAoUoj40Qqimaa0NLIOOAH4w==}
+  vite-node@3.1.2:
+    resolution: {integrity: sha512-/8iMryv46J3aK13iUXsei5G/A3CUlW4665THCPS+K8xAaqrVWiGB4RfXMQXCLjpK9P2eK//BczrVkn5JLAk6DA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -1428,16 +1428,16 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.1.1:
-    resolution: {integrity: sha512-kiZc/IYmKICeBAZr9DQ5rT7/6bD9G7uqQEki4fxazi1jdVl2mWGzedtBs5s6llz59yQhVb7FFY2MbHzHCnT79Q==}
+  vitest@3.1.2:
+    resolution: {integrity: sha512-WaxpJe092ID1C0mr+LH9MmNrhfzi8I65EX/NRU/Ld016KqQNRgxSOlGNP1hHN+a/F8L15Mh8klwaF77zR3GeDQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.1.1
-      '@vitest/ui': 3.1.1
+      '@vitest/browser': 3.1.2
+      '@vitest/ui': 3.1.2
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -2075,43 +2075,43 @@ snapshots:
 
   '@types/stylis@4.2.5': {}
 
-  '@vitest/expect@3.1.1':
+  '@vitest/expect@3.1.2':
     dependencies:
-      '@vitest/spy': 3.1.1
-      '@vitest/utils': 3.1.1
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.3.2(@types/node@22.14.1))':
+  '@vitest/mocker@3.1.2(vite@6.3.2(@types/node@22.14.1))':
     dependencies:
-      '@vitest/spy': 3.1.1
+      '@vitest/spy': 3.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.3.2(@types/node@22.14.1)
 
-  '@vitest/pretty-format@3.1.1':
+  '@vitest/pretty-format@3.1.2':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.1.1':
+  '@vitest/runner@3.1.2':
     dependencies:
-      '@vitest/utils': 3.1.1
+      '@vitest/utils': 3.1.2
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.1.1':
+  '@vitest/snapshot@3.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.1.1
+      '@vitest/pretty-format': 3.1.2
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.1.1':
+  '@vitest/spy@3.1.2':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.1.1':
+  '@vitest/utils@3.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.1.1
+      '@vitest/pretty-format': 3.1.2
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
@@ -2378,7 +2378,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-postinstall@0.1.1: {}
+  napi-postinstall@0.1.5: {}
 
   os-tmpdir@1.0.2: {}
 
@@ -2528,7 +2528,7 @@ snapshots:
 
   universal-user-agent@7.0.2: {}
 
-  vite-node@3.1.1(@types/node@22.14.1):
+  vite-node@3.1.2(@types/node@22.14.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
@@ -2561,15 +2561,15 @@ snapshots:
       '@types/node': 22.14.1
       fsevents: 2.3.3
 
-  vitest@3.1.1(@types/node@22.14.1):
+  vitest@3.1.2(@types/node@22.14.1):
     dependencies:
-      '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.3.2(@types/node@22.14.1))
-      '@vitest/pretty-format': 3.1.1
-      '@vitest/runner': 3.1.1
-      '@vitest/snapshot': 3.1.1
-      '@vitest/spy': 3.1.1
-      '@vitest/utils': 3.1.1
+      '@vitest/expect': 3.1.2
+      '@vitest/mocker': 3.1.2(vite@6.3.2(@types/node@22.14.1))
+      '@vitest/pretty-format': 3.1.2
+      '@vitest/runner': 3.1.2
+      '@vitest/snapshot': 3.1.2
+      '@vitest/spy': 3.1.2
+      '@vitest/utils': 3.1.2
       chai: 5.2.0
       debug: 4.4.0
       expect-type: 1.2.1
@@ -2578,10 +2578,11 @@ snapshots:
       std-env: 3.9.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
+      tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.3.2(@types/node@22.14.1)
-      vite-node: 3.1.1(@types/node@22.14.1)
+      vite-node: 3.1.2(@types/node@22.14.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.14.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,9 @@ packages:
   - napi
   - fixtures/pnpm
   - fixtures/pnpm-workspace/**
+
 ignoredBuiltDependencies:
   - esbuild
+
+# For `windows_symlinked_longfilename` in tests/resolve_test.rs
+virtualStoreDirMaxLength: 1024

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,10 @@ pub enum ResolveError {
     #[error("{0}")]
     IOError(IOError),
 
+    /// For example, Windows UNC path with Volume GUID is not supported.
+    #[error("Path {0:?} contains unsupported construct.")]
+    PathNotSupported(PathBuf),
+
     /// Node.js builtin module when `Options::builtin_modules` is enabled.
     ///
     /// `is_runtime_module` can be used to determine whether the request

--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -189,28 +189,16 @@ impl FileSystemOs {
     pub fn read_link(path: &Path) -> io::Result<PathBuf> {
         let path = fs::read_link(path)?;
         cfg_if! {
-            if #[cfg(windows)] {
-                Ok(Self::strip_windows_prefix(path))
+            if #[cfg(target_os = "windows")] {
+                match crate::windows::try_strip_windows_prefix(path) {
+                    // We won't follow the link if we cannot represent its target properly.
+                    Ok(p) | Err(crate::ResolveError::PathNotSupported(p)) => Ok(p),
+                    _ => unreachable!(),
+                }
             } else {
                 Ok(path)
             }
         }
-    }
-
-    pub fn strip_windows_prefix<P: AsRef<Path>>(path: P) -> PathBuf {
-        const UNC_PATH_PREFIX: &[u8] = b"\\\\?\\UNC\\";
-        const LONG_PATH_PREFIX: &[u8] = b"\\\\?\\";
-        let path_bytes = path.as_ref().as_os_str().as_encoded_bytes();
-        path_bytes
-            .strip_prefix(UNC_PATH_PREFIX)
-            .or_else(|| path_bytes.strip_prefix(LONG_PATH_PREFIX))
-            .map_or_else(
-                || path.as_ref().to_path_buf(),
-                |p| {
-                    // SAFETY: `as_encoded_bytes` ensures `p` is valid path bytes
-                    unsafe { PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(p)) }
-                },
-            )
     }
 }
 

--- a/src/fs_cache.rs
+++ b/src/fs_cache.rs
@@ -79,11 +79,12 @@ impl<Fs: FileSystem> Cache for FsCache<Fs> {
         let cached_path = self.canonicalize_impl(path)?;
         let path = cached_path.to_path_buf();
         cfg_if! {
-            if #[cfg(windows)] {
-                let path = crate::FileSystemOs::strip_windows_prefix(path);
+            if #[cfg(target_os = "windows")] {
+                crate::windows::try_strip_windows_prefix(path)
+            } else {
+                Ok(path)
             }
         }
-        Ok(path)
     }
 
     fn is_file(&self, path: &Self::Cp, ctx: &mut Ctx) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,8 @@ mod specifier;
 mod tsconfig;
 #[cfg(feature = "fs_cache")]
 mod tsconfig_serde;
+#[cfg(target_os = "windows")]
+mod windows;
 
 #[cfg(test)]
 mod tests;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use crate::ResolveError;
+
+/// When applicable, converts a [DOS device path](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths)
+/// to a normal path (usually, "Traditional DOS paths" or "UNC path") that can be consumed by the `import`/`require` syntax of Node.js.
+/// Returns `None` if the path cannot be represented as a normal path.
+pub fn try_strip_windows_prefix(path: PathBuf) -> Result<PathBuf, ResolveError> {
+    // See https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+    let path_bytes = path.as_os_str().as_encoded_bytes();
+
+    let path = if let Some(p) =
+        path_bytes.strip_prefix(br"\\?\UNC\").or_else(|| path_bytes.strip_prefix(br"\\.\UNC\"))
+    {
+        // UNC paths
+        // SAFETY:
+        unsafe {
+            PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(&[br"\\", p].concat()))
+        }
+    } else if let Some(p) =
+        path_bytes.strip_prefix(br"\\?\").or_else(|| path_bytes.strip_prefix(br"\\.\"))
+    {
+        // Assuming traditional DOS path "\\?\C:\"
+        if p[1] != b':' {
+            // E.g.,
+            // \\?\Volume{b75e2c83-0000-0000-0000-602f00000000}
+            // \\?\BootPartition\
+            // It seems nodejs does not support DOS device paths with Volume GUIDs.
+            // This can happen if the path points to a Mounted Volume without a drive letter.
+            return Err(ResolveError::PathNotSupported(path));
+        }
+        // SAFETY:
+        unsafe { PathBuf::from(std::ffi::OsStr::from_encoded_bytes_unchecked(p)) }
+    } else {
+        path
+    };
+
+    Ok(path)
+}
+
+#[test]
+fn test_try_strip_windows_prefix() {
+    let pass = [
+        (r"\\?\C:\Users\user\Documents\file1.txt", r"C:\Users\user\Documents\file1.txt"),
+        (r"\\.\C:\Users\user\Documents\file2.txt", r"C:\Users\user\Documents\file2.txt"),
+        (r"\\?\UNC\server\share\file3.txt", r"\\server\share\file3.txt"),
+    ];
+
+    for (path, expected) in pass {
+        assert_eq!(try_strip_windows_prefix(PathBuf::from(path)), Ok(PathBuf::from(expected)));
+    }
+
+    let fail = [
+        r"\\?\Volume{c8ec34d8-3ba6-45c3-9b9d-3e4148e12d00}\file4.txt",
+        r"\\?\BootPartition\file4.txt",
+    ];
+
+    for path in fail {
+        assert_eq!(
+            try_strip_windows_prefix(PathBuf::from(path)),
+            Err(crate::ResolveError::PathNotSupported(PathBuf::from(path)))
+        );
+    }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance Windows path handling, update dependencies, and adjust tests for long path support.
> 
>   - **Behavior**:
>     - Properly handle DOS device paths in `try_strip_windows_prefix()` in `src/windows.rs`.
>     - Update `ResolveError` in `src/error.rs` to include `PathNotSupported` for unsupported paths.
>   - **Dependencies**:
>     - Update `react` to `^19.1.0` in `fixtures/pnpm-workspace/packages/lib/package.json`.
>     - Update `napi-postinstall` to `^0.1.5` in `npm/package.json`.
>     - Update `vitest` to `^3.1.2` in `package.json`.
>   - **Testing**:
>     - Add tests for `try_strip_windows_prefix()` in `src/windows.rs`.
>     - Modify `windows_symlinked_longfilename` test in `tests/resolve_test.rs` to handle long paths on Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for ed82ebdba6ce17b51be026cda2e1b9cf5b87f720. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of DOS device paths on Windows to ensure proper path resolution and compatibility.
- **New Features**
  - Improved error reporting for unsupported Windows path constructs.
- **Chores**
  - Updated dependencies: "react" to 19.1.0, "napi-postinstall" to 0.1.5, and "vitest" to 3.1.2.
  - Added a configuration option to control virtual store directory length for workspace projects.
- **Documentation**
  - Updated changelog to reflect bug fixes related to Windows path handling.
- **Tests**
  - Enhanced and updated tests for Windows long path and symlink scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->