### PR TITLE
chore: release v1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.4](https://github.com/unrs/unrs-resolver/compare/v1.6.3...v1.6.4) - 2025-04-22
+
 ### <!-- 1 -->Bug Fixes
 
 - properly handle DOS device paths in strip_windows_prefix ([#455](https://github.com/oxc-project/oxc-resolver/pull/455))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,7 +1190,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "unrs_resolver"
-version = "1.6.3"
+version = "1.6.4"
 authors = ["JounQin <admin@1stg.me> (https://www.1stG.me)"]
 categories = ["development-tools"]
 edition = "2024"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "UnRS Resolver Node API with PNP support",
   "main": "index.js",
   "browser": "browser.js",


### PR DESCRIPTION


## 🤖 New release

* `unrs_resolver`: 1.6.3 -> 1.6.4

### ⚠ `unrs_resolver` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  FileSystemOs::strip_windows_prefix, previously in file /tmp/.tmpdiaYmq/unrs_resolver/src/file_system.rs:200
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Bump `unrs_resolver` version to 1.6.4 with a bug fix for DOS device path handling.
> 
>   - **Version Update**:
>     - Bump `unrs_resolver` version from 1.6.3 to 1.6.4 in `Cargo.toml`, `Cargo.lock`, and `npm/package.json`.
>   - **Bug Fix**:
>     - Fix handling of DOS device paths in `strip_windows_prefix` as noted in `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for c494a34b944f15fa008ee79b9f88fa4d898c1d73. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to include a new release entry for version 1.6.4, detailing a bug fix for handling DOS device paths.
- **Chores**
  - Bumped the package version to 1.6.4 in both Cargo and npm package files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->