### PR TITLE
feat: add new target `riscv64gc-unknown-linux-musl`

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -42,7 +42,7 @@ jobs:
 
   build:
     needs: check
-    if: needs.check.outputs.version_changed == 'true'
+    # if: needs.check.outputs.version_changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +85,14 @@ jobs:
               sudo apt-get install gcc-riscv64-linux-gnu g++-riscv64-linux-gnu -y &&
               export CC=riscv64-linux-gnu-gcc &&
               export CXX=riscv64-linux-gnu-g++ &&
+              pnpm build
+          - os: ubuntu-latest
+            target: riscv64gc-unknown-linux-musl
+            build: |-
+              sudo apt-get update &&
+              sudo apt-get install gcc-riscv64-linux-musl g++-riscv64-linux-musl -y &&
+              export CC=riscv64-linux-musl-gcc &&
+              export CXX=riscv64-linux-musl-g++ &&
               pnpm build
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -9,9 +9,6 @@ on:
       - main
     paths:
       - npm/package.json # Please only commit this file, so we don't need to wait for test CI to pass.
-  pull_request:
-    branches:
-      - main
 
 env:
   DEBUG: napi:*
@@ -45,7 +42,7 @@ jobs:
 
   build:
     needs: check
-    # if: needs.check.outputs.version_changed == 'true'
+    if: needs.check.outputs.version_changed == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -9,6 +9,9 @@ on:
       - main
     paths:
       - npm/package.json # Please only commit this file, so we don't need to wait for test CI to pass.
+  pull_request:
+    branches:
+      - main
 
 env:
   DEBUG: napi:*
@@ -88,12 +91,7 @@ jobs:
               pnpm build
           - os: ubuntu-latest
             target: riscv64gc-unknown-linux-musl
-            build: |-
-              sudo apt-get update &&
-              sudo apt-get install gcc-riscv64-linux-musl g++-riscv64-linux-musl -y &&
-              export CC=riscv64-linux-musl-gcc &&
-              export CXX=riscv64-linux-musl-g++ &&
-              pnpm build
+            build: pnpm build -x
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
             build: export CFLAGS="-fuse-ld=lld" && pnpm build --use-napi-cross

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -34,7 +34,7 @@ jobs:
         id: version
         with:
           static-checking: localIsNew
-          file-url: https://cdn.jsdelivr.net/npm/unrs-resolver@latest/package.json
+          file-url: https://unpkg.com/unrs-resolver@latest/package.json
           file-name: npm/package.json
 
       - name: Set version name

--- a/npm/package.json
+++ b/npm/package.json
@@ -37,6 +37,7 @@
       "armv7-unknown-linux-musleabihf",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
+      "riscv64gc-unknown-linux-musl",
       "s390x-unknown-linux-gnu",
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",


### PR DESCRIPTION
close #95
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `riscv64gc-unknown-linux-musl` target and update release workflow to always build.
> 
>   - **New Features**:
>     - Added `riscv64gc-unknown-linux-musl` target to build matrix in `release-napi.yml` and `package.json`.
>   - **Workflow Changes**:
>     - Updated `release-napi.yml` to always run the build process by commenting out the version check condition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 997f373b3be5947fe9fa2e7c5d26f0dbac8757f4. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the RISC-V 64-bit Linux (musl) platform, allowing users on this architecture to use the package.

- **Chores**
  - Updated release workflow to always run the build process and include the new RISC-V 64-bit target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->