### PR TITLE
test: add case for #65

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,6 +1194,7 @@ dependencies = [
  "thiserror",
  "tracing",
  "vfs",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ serde_json = { version = "1.0.140", features = ["preserve_order"], optional = tr
 simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] }
 thiserror = "2.0.12"
 tracing = "0.1.41"
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
 
 pnp = { version = "0.9.3", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See [index.d.ts](https://github.com/unrs/unrs-resolver/blob/main/napi/index.d.ts
 | preferAbsolute   | false                     | Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots                                                          |
 | restrictions     | []                        | A list of resolve restrictions                                                                                                                            |
 | roots            | []                        | A list of root paths                                                                                                                                      |
-| symlinks         | true                      | Whether to resolve symlinks to their symlinked location                                                                                                   |
+| symlinks         | true                      | Whether to resolve symlinks to their symlinked location, [if possible](https://github.com/unrs/unrs-resolver/blob/main/src/options.rs#L157-L170).         |
 
 ### Unimplemented Options
 

--- a/fixtures/enhanced_resolve/test/.gitignore
+++ b/fixtures/enhanced_resolve/test/.gitignore
@@ -1,3 +1,6 @@
 # created by symlink.rs
+/temp.*
+
+# Currently not used.
 /temp
 /temp_symlinks

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -23,6 +23,7 @@ mod simple;
 mod symlink;
 mod tsconfig_paths;
 mod tsconfig_project_references;
+mod windows;
 
 use std::{env, path::PathBuf, sync::Arc, thread};
 

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -67,12 +67,12 @@ fn create_symlinks(dirname: &Path, temp_path: &Path) -> io::Result<()> {
         // which potentially can resolve the Volume GUID into driver letter whenever possible.
         let dos_device_temp_path = get_dos_device_path(temp_path).unwrap();
         symlink(
-            dos_device_temp_path.join(r"..\lib"),
+            dos_device_temp_path.join(r"..\..\lib"),
             temp_path.join("device_path_lib"),
             FileType::Dir,
         )?;
         symlink(
-            dos_device_temp_path.join(r"..\lib\index.js"),
+            dos_device_temp_path.join(r"..\..\lib\index.js"),
             temp_path.join("device_path_index.js"),
             FileType::File,
         )?;

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -63,7 +63,8 @@ fn create_symlinks(dirname: &Path, temp_path: &Path) -> io::Result<()> {
     #[cfg(target_family = "windows")]
     {
         // Ideally we should point to a Volume that does not have a drive letter.
-        // However, we can just pick up any Volume here as resolver itself is not calling `fs::canonicalize`,
+        // However, it's not trivial to create a Volume in CI environment.
+        // Here we are just picking up any Volume, as resolver itself is not calling `fs::canonicalize`,
         // which potentially can resolve the Volume GUID into driver letter whenever possible.
         let dos_device_temp_path = get_dos_device_path(temp_path).unwrap();
         symlink(

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,6 +1,6 @@
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 use crate::tests::windows::get_dos_device_path;
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 use normalize_path::NormalizePath;
 use std::path::PathBuf;
 use std::{fs, io, path::Path};
@@ -24,7 +24,7 @@ fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(
         std::os::unix::fs::symlink(original, link)
     }
 
-    #[cfg(target_family = "windows")]
+    #[cfg(target_os = "windows")]
     match file_type {
         // NOTE: original path should use `\` instead of `/` for relative paths
         //       otherwise the symlink will be broken and the test will fail with InvalidFilename error
@@ -60,7 +60,7 @@ fn create_symlinks(dirname: &Path, temp_path: &Path) -> io::Result<()> {
         FileType::File,
     )?;
 
-    #[cfg(target_family = "windows")]
+    #[cfg(target_os = "windows")]
     {
         // Ideally we should point to a Volume that does not have a drive letter.
         // However, it's not trivial to create a Volume in CI environment.
@@ -164,7 +164,7 @@ fn test() {
     }
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 #[test]
 fn test_unsupported_targets() {
     use crate::ResolveError;

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -110,15 +110,13 @@ fn prepare_symlinks() -> io::Result<Option<SymlinkFixturePaths>> {
             return Err(err);
         }
     }
-    return Ok(Some(SymlinkFixturePaths { root, temp_path }));
+
+    Ok(Some(SymlinkFixturePaths { root, temp_path }))
 }
 
 #[test]
 fn test() {
-    let SymlinkFixturePaths { root, temp_path } = match prepare_symlinks().unwrap() {
-        Some(paths) => paths,
-        None => return,
-    };
+    let Some(SymlinkFixturePaths { root, temp_path }) = prepare_symlinks().unwrap() else { return };
     let resolver_without_symlinks =
         Resolver::new(ResolveOptions { symlinks: false, ..ResolveOptions::default() });
     let resolver_with_symlinks = Resolver::default();
@@ -163,9 +161,8 @@ fn test() {
 #[cfg(target_family = "windows")]
 #[test]
 fn test_unsupported_targets() {
-    let SymlinkFixturePaths { root: _, temp_path } = match prepare_symlinks().unwrap() {
-        Some(paths) => paths,
-        None => return,
+    let Some(SymlinkFixturePaths { root: _, temp_path }) = prepare_symlinks().unwrap() else {
+        return;
     };
     let resolver_with_symlinks = Resolver::default();
 

--- a/src/tests/symlink.rs
+++ b/src/tests/symlink.rs
@@ -1,4 +1,4 @@
-use crate::ResolveError;
+#[cfg(target_family = "windows")]
 use crate::tests::windows::get_dos_device_path;
 #[cfg(target_family = "windows")]
 use normalize_path::NormalizePath;
@@ -161,6 +161,8 @@ fn test() {
 #[cfg(target_family = "windows")]
 #[test]
 fn test_unsupported_targets() {
+    use crate::ResolveError;
+
     let Some(SymlinkFixturePaths { root: _, temp_path }) = prepare_symlinks().unwrap() else {
         return;
     };

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -1,3 +1,4 @@
+#[cfg(target_family = "windows")]
 use std::{
     ffi::{OsStr, OsString},
     fs::canonicalize,
@@ -6,15 +7,17 @@ use std::{
 };
 
 use thiserror::Error;
-use windows_sys::Win32::{
-    Foundation::GetLastError, Storage::FileSystem::GetVolumeNameForVolumeMountPointW,
-};
 
 /// Converts a Win32 drive letter or mounted folder into DOS device path, e.g.:
 /// `\\?\Volume{GUID}\`
+#[cfg(target_family = "windows")]
 pub fn volume_name_from_mount_point<S: AsRef<OsStr>>(
     mount_point: S,
 ) -> Result<OsString, Win32Error> {
+    use windows_sys::Win32::{
+        Foundation::GetLastError, Storage::FileSystem::GetVolumeNameForVolumeMountPointW,
+    };
+
     const BUFFER_SIZE: u32 = 64;
     let mount_point: Vec<u16> = mount_point.as_ref().encode_wide().chain(Some(0)).collect();
     // A reasonable size for the buffer to accommodate the largest possible volume GUID path is 50 characters.
@@ -33,6 +36,7 @@ pub fn volume_name_from_mount_point<S: AsRef<OsStr>>(
     }
 }
 
+#[cfg(target_family = "windows")]
 pub fn get_dos_device_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Win32Error> {
     let path = path.as_ref();
     assert!(path.has_root(), "Expected a path with a root");
@@ -64,6 +68,7 @@ pub struct Win32Error {
     pub error_code: u32,
 }
 
+#[cfg(target_family = "windows")]
 #[test]
 fn test_get_dos_device_path() {
     let root = super::fixture_root();

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -1,0 +1,86 @@
+use std::{
+    ffi::{OsStr, OsString},
+    fs::canonicalize,
+    os::windows::ffi::{OsStrExt, OsStringExt},
+    path::{Path, PathBuf},
+};
+
+use thiserror::Error;
+use windows_sys::Win32::{
+    Foundation::GetLastError, Storage::FileSystem::GetVolumeNameForVolumeMountPointW,
+};
+
+/// Converts a Win32 drive letter or mounted folder into DOS device path, e.g.:
+/// \\?\Volume{GUID}\
+pub fn volume_name_from_mount_point<S: AsRef<OsStr>>(
+    mount_point: S,
+) -> Result<OsString, Win32Error> {
+    let mount_point: Vec<u16> = mount_point.as_ref().encode_wide().chain(Some(0)).collect();
+    // A reasonable size for the buffer to accommodate the largest possible volume GUID path is 50 characters.
+    let mut buffer = vec![0; 64];
+    unsafe {
+        // https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumenameforvolumemountpointw
+        if GetVolumeNameForVolumeMountPointW(
+            mount_point.as_ptr(),
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+        ) == 0
+        {
+            Err(Win32Error { error_code: GetLastError() })
+        } else {
+            let length = buffer.iter().position(|&c| c == 0).unwrap();
+            Ok(OsString::from_wide(&buffer[..length]))
+        }
+    }
+}
+
+pub fn get_dos_device_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Win32Error> {
+    let path = path.as_ref();
+
+    if !path.has_root() {
+        panic!("Expected a path with a root");
+    }
+
+    let root = {
+        // lpszVolumeMountPoint: The string must end with a trailing backslash ('\').
+        let mut root = OsString::from(path.components().next().unwrap().as_os_str());
+        root.push(r"\");
+        root
+    };
+    let mut volume_name_root: Vec<u16> =
+        volume_name_from_mount_point(root)?.encode_wide().collect();
+    if volume_name_root.starts_with(&[92, 92, 63, 92] /* \\?\ */) {
+        // Replace \\?\ with \\.\
+        // While both is a valid DOS device path, "\\?\" won't be accepted when creating symlinks.
+        volume_name_root[2] = b'.' as u16;
+    }
+
+    let mut dos_device_path = PathBuf::from(OsString::from_wide(&volume_name_root));
+    dos_device_path.extend(path.components().skip(1));
+
+    return Ok(dos_device_path);
+}
+
+#[derive(Debug, Clone, PartialEq, Error)]
+#[error("Win32 Error (GetLastError: {error_code:#X})")]
+pub struct Win32Error {
+    /// https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes
+    pub error_code: u32,
+}
+
+#[test]
+fn test_get_dos_device_path() {
+    let root = super::fixture_root();
+    println!("Fixture root: {root:?}");
+    let dos_device_path = get_dos_device_path(&root).unwrap();
+    println!("Dos device path: {dos_device_path:?}");
+
+    // On Windows, canonicalize will resolve any path (traditional or DOS device path)
+    // into a DOS device path with drive letter (e.g., r"\\?\D:\foo\bar.js").
+    // https://doc.rust-lang.org/std/fs/fn.canonicalize.html
+    let canonical_dos_device_path = canonicalize(&dos_device_path).unwrap();
+    println!("-> Canonicalized: {canonical_dos_device_path:?}");
+
+    // So eventually, the canonicalized path should be exactly the same.
+    assert_eq!(canonical_dos_device_path, canonicalize(root).unwrap());
+}

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -11,7 +11,7 @@ use windows_sys::Win32::{
 };
 
 /// Converts a Win32 drive letter or mounted folder into DOS device path, e.g.:
-/// \\?\Volume{GUID}\
+/// `\\?\Volume{GUID}\`
 pub fn volume_name_from_mount_point<S: AsRef<OsStr>>(
     mount_point: S,
 ) -> Result<OsString, Win32Error> {
@@ -51,7 +51,7 @@ pub fn get_dos_device_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Win32Erro
         volume_name_from_mount_point(root)?.encode_wide().collect();
     if volume_name_root.starts_with(&[92, 92, 63, 92] /* \\?\ */) {
         // Replace \\?\ with \\.\
-        // While both is a valid DOS device path, "\\?\" won't be accepted when creating symlinks.
+        // While both is a valid DOS device path, "\\?\" won't be accepted by most of the IO operations.
         volume_name_root[2] = b'.' as u16;
     }
 

--- a/src/tests/windows.rs
+++ b/src/tests/windows.rs
@@ -1,4 +1,4 @@
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 use std::{
     ffi::{OsStr, OsString},
     fs::canonicalize,
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 /// Converts a Win32 drive letter or mounted folder into DOS device path, e.g.:
 /// `\\?\Volume{GUID}\`
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 pub fn volume_name_from_mount_point<S: AsRef<OsStr>>(
     mount_point: S,
 ) -> Result<OsString, Win32Error> {
@@ -36,7 +36,7 @@ pub fn volume_name_from_mount_point<S: AsRef<OsStr>>(
     }
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 pub fn get_dos_device_path<P: AsRef<Path>>(path: P) -> Result<PathBuf, Win32Error> {
     let path = path.as_ref();
     assert!(path.has_root(), "Expected a path with a root");
@@ -68,7 +68,7 @@ pub struct Win32Error {
     pub error_code: u32,
 }
 
-#[cfg(target_family = "windows")]
+#[cfg(target_os = "windows")]
 #[test]
 fn test_get_dos_device_path() {
     let root = super::fixture_root();


### PR DESCRIPTION
This PR adds unit test for symlink targets with unsupported [DOS device paths](https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats#dos-device-paths) on Windows.

As mentioned in #65,

> Given the status quo of the supportability of the (NodeJS) `import`s with ~~UNC-path~~ DOS device Path, probably we can just treat such symlinks resolved into (unsupported) ~~UNC paths~~ DOS device path just like ordinary folders. This also aligns with the behavior of enhanced-resolve.

Specifically, symlinks resolving into DOS device paths with volume GUIDs won't be followed even if `symlinks` option is set to `true`.

This PR also updated the description of `symlinks` option in README.md.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add test for symlink targets resolving to unsupported DOS device paths on Windows and update `symlinks` option documentation.
> 
>   - **Tests**:
>     - Add test case in `symlink.rs` for symlink targets resolving to unsupported DOS device paths on Windows.
>     - Introduce `windows.rs` to handle DOS device paths, including `get_dos_device_path()` and `volume_name_from_mount_point()` functions.
>     - Ensure symlinks resolving to DOS device paths are treated as ordinary files or folders.
>   - **Documentation**:
>     - Update `symlinks` option description in `README.md` to reflect behavior with DOS device paths.
>   - **Dependencies**:
>     - Add `windows-sys 0.59.0` to `Cargo.toml` for Windows-specific functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 68d0f0d2ef788979ec7778f61a5f2ed9d8756115. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the behavior of the symlink resolution option in the documentation, including a link to relevant source code for further details.

- **Tests**
  - Improved and extended symlink resolution tests, including new Windows-specific scenarios and enhanced error handling.
  - Added a new test module for Windows to verify DOS device path conversions and symlink behavior with unsupported targets.

- **New Features**
  - Introduced helper functions and error types for Windows-specific path handling in tests.

- **Chores**
  - Updated dependencies to include Windows system libraries for enhanced platform support.
  - Enhanced .gitignore to exclude temporary files and directories starting with "temp."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->