### PR TITLE
fix: bump `napi-postinstall` to fix yarn pnp compatibility issue

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -19,7 +19,7 @@
     "postinstall": "napi-postinstall unrs-resolver 1.7.1 check"
   },
   "dependencies": {
-    "napi-postinstall": "^0.2.1"
+    "napi-postinstall": "^0.2.2"
   },
   "napi": {
     "binaryName": "resolver",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
   npm:
     dependencies:
       napi-postinstall:
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.2.2
+        version: 0.2.2
 
 packages:
 
@@ -1213,8 +1213,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-postinstall@0.2.1:
-    resolution: {integrity: sha512-3VK+GygwU4OMkBYdQLpRjxnt7idAsZAN5hnrWLHIAu4X+uO4uhqrIggKF1TacBV9OPUMwTb1sQQvwKRzfXLnQg==}
+  napi-postinstall@0.2.2:
+    resolution: {integrity: sha512-Wy1VI/hpKHwy1MsnFxHCJxqFwmmxD0RA/EKPL7e6mfbsY01phM2SZyJnRdU0bLvhu0Quby1DCcAZti3ghdl4/A==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
     hasBin: true
 
@@ -2378,7 +2378,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-postinstall@0.2.1: {}
+  napi-postinstall@0.2.2: {}
 
   os-tmpdir@1.0.2: {}
 


### PR DESCRIPTION
close #105
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `napi-postinstall` to `^0.2.2` in `package.json` to fix Yarn PnP compatibility issue.
> 
>   - **Dependencies**:
>     - Bump `napi-postinstall` version from `^0.2.1` to `^0.2.2` in `package.json` to fix Yarn PnP compatibility issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 6508b6541e9a4c8128e010c8050cbe7d0b4a608a. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of a dependency to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->