### PR TITLE
fix: custom `condition_names` should take higher priority than target in package.json

### DIFF
--- a/fixtures/dual-condition-names/package.json
+++ b/fixtures/dual-condition-names/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dual-condition-names",
+  "dependencies": {
+    "zod": "~3.24.4"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
         specifier: ^3.1.4
         version: 3.1.4(@types/node@22.15.21)
 
+  fixtures/dual-condition-names:
+    dependencies:
+      zod:
+        specifier: ~3.24.4
+        version: 3.24.4
+
   fixtures/pnpm:
     devDependencies:
       '@oxc-resolver/test-longfilename-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa':
@@ -1472,6 +1478,9 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
+
 snapshots:
 
   '@babel/runtime@7.27.0':
@@ -2614,3 +2623,5 @@ snapshots:
       strip-ansi: 6.0.1
 
   yoctocolors-cjs@2.1.2: {}
+
+  zod@3.24.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - npm
   - napi
+  - fixtures/dual-condition-names
   - fixtures/pnpm
   - fixtures/pnpm-workspace/**
 

--- a/src/tests/exports_field.rs
+++ b/src/tests/exports_field.rs
@@ -822,7 +822,7 @@ fn test_cases() {
         },
         TestCase {
             name: "Direct mapping #7",
-            expect: Some(vec!["./src/index.js"]), // `enhanced_resolve` is `None`
+            expect: Some(vec!["./index.js"]), // `enhanced_resolve` is `None`
             exports_field: exports_field(json!({
                 ".": {
                     "default": "./src/index.js",
@@ -1344,7 +1344,7 @@ fn test_cases() {
                 }
             })),
             request: "./utils/index.mjs",
-            condition_names: vec!["browser", "webpack"],
+            condition_names: vec!["webpack", "browser"],
         },
         TestCase {
             name: "conditional mapping folder #3 (wildcard)",
@@ -1362,7 +1362,7 @@ fn test_cases() {
                 }
             })),
             request: "./utils/index.mjs",
-            condition_names: vec!["browser", "webpack"],
+            condition_names: vec!["webpack", "browser"],
         },
         TestCase {
             name: "incorrect exports field #1",

--- a/src/tests/imports_field.rs
+++ b/src/tests/imports_field.rs
@@ -517,7 +517,7 @@ fn test_cases() {
         },
         TestCase {
             name: "Direct mapping #7",
-            expect: Some(vec!["./src/index.js"]), // `enhanced_resolve` is `None`
+            expect: Some(vec!["./index.js"]), // `enhanced_resolve` is `None`
             imports_field: imports_field(json!({
               "#a": {
                 "default": "./src/index.js",
@@ -905,7 +905,7 @@ fn test_cases() {
               }
             })),
             request: "#a/index.mjs",
-            condition_names: vec!["browser", "webpack"],
+            condition_names: vec!["webpack", "browser"],
         },
         TestCase {
             name: "incorrect exports field #1",

--- a/tests/resolve_test.rs
+++ b/tests/resolve_test.rs
@@ -247,3 +247,17 @@ fn package_json_with_bom() {
         Ok(dir.join("package-json-with-bom/index.js"))
     );
 }
+
+#[test]
+fn dual_condition_names() {
+    let dir: PathBuf = dir();
+    let path = dir.join("fixtures/dual-condition-names");
+    let resolver = Resolver::new(ResolveOptions {
+        condition_names: vec!["import".into(), "require".into()],
+        ..ResolveOptions::default()
+    });
+    assert_eq!(
+        resolver.resolve(path, "zod").map(|r| r.full_path()),
+        Ok(dir.join("node_modules/.pnpm/zod@3.24.4/node_modules/zod/lib/index.mjs"))
+    );
+}


### PR DESCRIPTION
related https://github.com/un-ts/eslint-plugin-import-x/pull/272#issuecomment-2911623534
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Custom `condition_names` now take precedence over `default` in module resolution, with new tests and fixtures added.
> 
>   - **Behavior**:
>     - Custom `condition_names` now take precedence over `default` in `src/lib.rs`.
>     - Adds `default` as a fallback condition if not present.
>   - **Fixtures**:
>     - Adds `dual-condition-names/package.json` with dependency `zod`.
>     - Updates `pnpm-workspace.yaml` to include `fixtures/dual-condition-names`.
>   - **Tests**:
>     - Adds `dual_condition_names()` test in `resolve_test.rs` to verify module resolution with multiple condition names.
>     - Modifies test cases in `exports_field.rs` and `imports_field.rs` to reflect new condition name precedence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 6e0f63ac2d0a213b511586fa5d695e7d6f685fb3. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new fixture for dual condition names with its own package configuration.
  - Workspace now includes the new dual-condition-names fixture for easier management.
- **Tests**
  - Introduced a new test to verify correct module resolution when multiple condition names are used.
  - Updated test cases to reflect changes in condition name order and resolved paths for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->