### PR TITLE
chore: release v1.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.6](https://github.com/unrs/unrs-resolver/compare/v1.7.5...v1.7.6) - 2025-05-28
+
+### <!-- 1 -->Bug Fixes
+
+- prefer index over current file for `.` and `./` ([#121](https://github.com/unrs/unrs-resolver/pull/121))
+
 ## [1.7.5](https://github.com/unrs/unrs-resolver/compare/v1.7.4...v1.7.5) - 2025-05-28
 
 ### <!-- 1 -->Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.7.5"
+version = "1.7.6"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "unrs_resolver"
-version = "1.7.5"
+version = "1.7.6"
 authors = ["JounQin <admin@1stg.me> (https://www.1stG.me)"]
 categories = ["development-tools"]
 edition = "2024"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.7.5",
+  "version": "1.7.6",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -16,7 +16,7 @@
     "browser.js"
   ],
   "scripts": {
-    "postinstall": "napi-postinstall unrs-resolver 1.7.5 check"
+    "postinstall": "napi-postinstall unrs-resolver 1.7.6 check"
   },
   "dependencies": {
     "napi-postinstall": "^0.2.2"


### PR DESCRIPTION



## 🤖 New release

* `unrs_resolver`: 1.7.5 -> 1.7.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.7.6](https://github.com/unrs/unrs-resolver/compare/v1.7.5...v1.7.6) - 2025-05-28

### <!-- 1 -->Bug Fixes

- prefer index over current file for `.` and `./` ([#121](https://github.com/unrs/unrs-resolver/pull/121))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `unrs_resolver` to v1.7.6 with a bug fix prioritizing index over current file for certain paths.
> 
>   - **Version Update**:
>     - Bump `unrs_resolver` version from 1.7.5 to 1.7.6 in `Cargo.toml` and `Cargo.lock`.
>   - **Bug Fix**:
>     - Prefer index over current file for `.` and `./` paths (see `CHANGELOG.md`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 75684cc935eb1db97d5533fc9dfba526d54d14c8. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where path resolution now correctly prefers the index file over the current file for `.` and `./` paths.

- **Chores**
  - Updated version numbers to 1.7.6 in relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->