### PR TITLE
chore: release v1.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.10](https://github.com/unrs/unrs-resolver/compare/v1.7.9...v1.7.10) - 2025-06-05
+
+### <!-- 1 -->Bug Fixes
+
+- Revert "fix: custom `condition_names` should take higher priority than target in package.json ([#115](https://github.com/unrs/unrs-resolver/pull/115))" ([#131](https://github.com/unrs/unrs-resolver/pull/131))
+
+### Other
+
+- chore: bump napi v3.0.0-beta.7 ([#133](https://github.com/unrs/unrs-resolver/pull/133))
+
 ## [1.7.9](https://github.com/unrs/unrs-resolver/compare/v1.7.8...v1.7.9) - 2025-06-03
 
 ### <!-- 1 -->Bug Fixes
 
 - pnp global cache should be supported ([#129](https://github.com/unrs/unrs-resolver/pull/129))
 
-   Windows global cache is still unsupported due to upstream
+  Windows global cache is still unsupported due to upstream
 
-   see also <https://github.com/yarnpkg/pnp-rs/pull/10>
+  see also <https://github.com/yarnpkg/pnp-rs/pull/10>
 
 ## [1.7.8](https://github.com/unrs/unrs-resolver/compare/v1.7.7...v1.7.8) - 2025-05-29
 
@@ -153,7 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - handle query and fragment in pacakge.json `exports` and `imports` field ([#443](https://github.com/oxc-project/oxc-resolver/pull/443))
 - resolve emitDecoratorMetadata in tsconfig ([#439](https://github.com/oxc-project/oxc-resolver/pull/439))
-- *(napi)* add mimalloc ([#423](https://github.com/oxc-project/oxc-resolver/pull/423))
+- _(napi)_ add mimalloc ([#423](https://github.com/oxc-project/oxc-resolver/pull/423))
 - [**breaking**] Rust Edition 2024 ([#402](https://github.com/oxc-project/oxc-resolver/pull/402))
 - deserialize `verbatim_module_syntax` from compilerOptions ([#411](https://github.com/oxc-project/oxc-resolver/pull/411))
 - support wildcard `*` in alias plugin ([#388](https://github.com/oxc-project/oxc-resolver/pull/388))
@@ -181,7 +191,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - use `fs::canonicalize` to cover symlink edge cases ([#284](https://github.com/oxc-project/oxc-resolver/pull/284))
 - extensionAlias cannot resolve mathjs ([#273](https://github.com/oxc-project/oxc-resolver/pull/273))
 - resolve module `ipaddr.js` correctly when `extensionAlias` is provided ([#228](https://github.com/oxc-project/oxc-resolver/pull/228))
-- *(napi)* update buggy NAPI-RS versions ([#225](https://github.com/oxc-project/oxc-resolver/pull/225))
+- _(napi)_ update buggy NAPI-RS versions ([#225](https://github.com/oxc-project/oxc-resolver/pull/225))
 - remove `#[cfg(target_os = "windows")]` logic in `canonicalize` ([#221](https://github.com/oxc-project/oxc-resolver/pull/221))
 
 ### <!-- 2 -->Performance
@@ -203,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - fix an incorrect comment on `Context::missing_dependencies`
 - mention extension must start with a `.` in `with_extension` ([#313](https://github.com/oxc-project/oxc-resolver/pull/313))
-- *(README)* should be `new ResolverFactory`
+- _(README)_ should be `new ResolverFactory`
 
 ### <!-- 4 -->Refactor
 
@@ -251,13 +261,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### <!-- 1 -->Bug Fixes
 
-- *(pnp)* support `pnpapi` core module and package deep link ([#24](https://github.com/unrs/unrs-resolver/pull/24))
+- _(pnp)_ support `pnpapi` core module and package deep link ([#24](https://github.com/unrs/unrs-resolver/pull/24))
 
 ## [1.2.0](https://github.com/unrs/unrs-resolver/compare/unrspack-resolver-v1.1.2...unrspack-resolver-v2.0.0) - 2025-03-18
 
 ### <!-- 0 -->Features
 
-- *(napi)* add mimalloc ([#423](https://github.com/unrs/unrs-resolver/pull/423)) ([#18](https://github.com/unrs/unrs-resolver/pull/18))
+- _(napi)_ add mimalloc ([#423](https://github.com/unrs/unrs-resolver/pull/423)) ([#18](https://github.com/unrs/unrs-resolver/pull/18))
 - merge from upstream `oxc-project/oxc-resolver` ([#15](https://github.com/unrs/unrs-resolver/pull/15))
 
 ## [1.1.2](https://github.com/unrs/unrs-resolver/compare/unrspack-resolver-v1.1.1...unrspack-resolver-v1.1.2) - 2025-03-16

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,7 +1232,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.7.9"
+version = "1.7.10"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "unrs_resolver"
-version = "1.7.9"
+version = "1.7.10"
 authors = ["JounQin <admin@1stg.me> (https://www.1stG.me)"]
 categories = ["development-tools"]
 edition = "2024"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -16,7 +16,7 @@
     "browser.js"
   ],
   "scripts": {
-    "postinstall": "napi-postinstall unrs-resolver 1.7.9 check"
+    "postinstall": "napi-postinstall unrs-resolver 1.7.10 check"
   },
   "dependencies": {
     "napi-postinstall": "^0.2.2"


### PR DESCRIPTION
## 🤖 New release

* `unrs_resolver`: 1.7.9 -> 1.7.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.7.10](https://github.com/unrs/unrs-resolver/compare/v1.7.9...v1.7.10) - 2025-06-05

### <!-- 1 -->Bug Fixes

- Revert "fix: custom `condition_names` should take higher priority than target in package.json ([#115](https://github.com/unrs/unrs-resolver/pull/115))" ([#131](https://github.com/unrs/unrs-resolver/pull/131))

### Other

- chore: bump napi v3.0.0-beta.7 ([#133](https://github.com/unrs/unrs-resolver/pull/133))

</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `unrs_resolver` version to 1.7.10 with API-compatible changes and fix PnP global cache support.
> 
>   - **Release**:
>     - Bump `unrs_resolver` version from 1.7.9 to 1.7.10 in `Cargo.toml` and `Cargo.lock`.
>     - Includes API-compatible changes.
>   - **Bug Fixes**:
>     - Fix PnP global cache support issue (Windows still unsupported).
>   - **Misc**:
>     - Generated by `release-plz`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for ec18dca80d49adbd22bfdb2010695f5eae59c45a. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->