### PR TITLE
fix: enabled extension of referenced configs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1328,11 +1328,7 @@ impl<C: Cache<Cp = FsCachedPath>> ResolverGeneric<C> {
         })
     }
 
-    fn extend_tsconfig(
-        &self,
-        directory: &C::Cp,
-        tsconfig: &mut C::Tc
-    ) -> Result<(), ResolveError> {
+    fn extend_tsconfig(&self, directory: &C::Cp, tsconfig: &mut C::Tc) -> Result<(), ResolveError> {
         let extended_tsconfig_paths = tsconfig
             .extends()
             .map(|specifier| self.get_extended_tsconfig_path(&directory, tsconfig, specifier))
@@ -1348,18 +1344,13 @@ impl<C: Cache<Cp = FsCachedPath>> ResolverGeneric<C> {
         Ok(())
     }
 
-    fn load_tsconfig_references(
-        &self,
-        tsconfig: &mut C::Tc
-    ) -> Result<(), ResolveError> {
+    fn load_tsconfig_references(&self, tsconfig: &mut C::Tc) -> Result<(), ResolveError> {
         let path = tsconfig.path().to_path_buf();
         let directory = tsconfig.directory().to_path_buf();
         for reference in tsconfig.references_mut() {
             let reference_tsconfig_path = directory.normalize_with(reference.path());
             if reference_tsconfig_path == path {
-                return Err(ResolveError::TsconfigSelfReference(
-                    reference_tsconfig_path,
-                ));
+                return Err(ResolveError::TsconfigSelfReference(reference_tsconfig_path));
             }
             let referenced_tsconfig = self.load_tsconfig(
                 /* root */ false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1331,7 +1331,7 @@ impl<C: Cache<Cp = FsCachedPath>> ResolverGeneric<C> {
     fn extend_tsconfig(&self, directory: &C::Cp, tsconfig: &mut C::Tc) -> Result<(), ResolveError> {
         let extended_tsconfig_paths = tsconfig
             .extends()
-            .map(|specifier| self.get_extended_tsconfig_path(&directory, tsconfig, specifier))
+            .map(|specifier| self.get_extended_tsconfig_path(directory, tsconfig, specifier))
             .collect::<Result<Vec<_>, _>>()?;
         for extended_tsconfig_path in extended_tsconfig_paths {
             let extended_tsconfig = self.load_tsconfig(


### PR DESCRIPTION
This PR enables extension of referenced configs as explained in this issue: https://github.com/import-js/eslint-import-resolver-typescript/issues/400

For reference, to for tsconfigs in the `references` field have not been post-processed (i.e. no resolution of "extends" keyword). This PR introduces the default `load_config` function for all referenced configs, which also ensures that extended configs will be loaded properly.

⚠️ I am not a RUST developer and the changes have been untested @JounQin, can you please take a look at this! The PR is allowed to be updated by maintainers.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `load_tsconfig` in `src/lib.rs` to extend referenced TypeScript configs by resolving `extends` keyword.
> 
>   - **Behavior**:
>     - `load_tsconfig` in `src/lib.rs` now extends referenced TypeScript configs using `extend_tsconfig` and `load_tsconfig_references`.
>     - Ensures `extends` keyword in tsconfigs is resolved.
>   - **Functions**:
>     - New `extend_tsconfig` function to handle extending tsconfigs.
>     - New `load_tsconfig_references` function to load references in tsconfigs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 690aa39bf5f9c4dcbe5b5e6c03c3c928837d4234. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved internal structure for loading configuration files, resulting in clearer and more maintainable logic. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->