### PR TITLE
fix: npm protocol alias with pnp should be supported

### DIFF
--- a/fixtures/global-pnp/package.json
+++ b/fixtures/global-pnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-pnp",
-  "packageManager": "yarn@4.9.1",
+  "packageManager": "yarn@4.9.2",
   "dependencies": {
     "source-map-support": "^0.5.21"
   }

--- a/fixtures/pnp/package.json
+++ b/fixtures/pnp/package.json
@@ -3,12 +3,14 @@
   "packageManager": "yarn@4.9.2",
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.5.2",
+    "@custom/pragmatic-drag-and-drop": "npm:@atlaskit/pragmatic-drag-and-drop@^1.5.2",
     "beachball": "^2.52.0",
     "custom-minimist": "npm:minimist@^1.2.8",
     "is-even": "^1.0.0",
     "is-odd": "^3.0.1",
     "lib": "link:./shared",
     "lodash.zip": "^4.2.0",
+    "pragmatic-drag-and-drop": "npm:@atlaskit/pragmatic-drag-and-drop@^1.5.2",
     "preact": "^10.26.5"
   }
 }

--- a/fixtures/pnp/package.json
+++ b/fixtures/pnp/package.json
@@ -1,9 +1,10 @@
 {
   "name": "pnp",
-  "packageManager": "yarn@4.9.1",
+  "packageManager": "yarn@4.9.2",
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.5.2",
     "beachball": "^2.52.0",
+    "custom-minimist": "npm:minimist@^1.2.8",
     "is-even": "^1.0.0",
     "is-odd": "^3.0.1",
     "lib": "link:./shared",

--- a/fixtures/pnp/yarn.lock
+++ b/fixtures/pnp/yarn.lock
@@ -188,6 +188,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"custom-minimist@npm:minimist@^1.2.8":
+  version: 1.2.8
+  resolution: "minimist@npm:1.2.8"
+  checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
+  languageName: node
+  linkType: hard
+
 "dir-glob@npm:^3.0.1":
   version: 3.0.1
   resolution: "dir-glob@npm:3.0.1"
@@ -683,6 +690,7 @@ __metadata:
   dependencies:
     "@atlaskit/pragmatic-drag-and-drop": "npm:^1.5.2"
     beachball: "npm:^2.52.0"
+    custom-minimist: "npm:minimist@^1.2.8"
     is-even: "npm:^1.0.0"
     is-odd: "npm:^3.0.1"
     lib: "link:./shared"

--- a/fixtures/pnp/yarn.lock
+++ b/fixtures/pnp/yarn.lock
@@ -5,7 +5,7 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@atlaskit/pragmatic-drag-and-drop@npm:^1.5.2":
+"@atlaskit/pragmatic-drag-and-drop@npm:^1.5.2, @custom/pragmatic-drag-and-drop@npm:@atlaskit/pragmatic-drag-and-drop@^1.5.2, pragmatic-drag-and-drop@npm:@atlaskit/pragmatic-drag-and-drop@^1.5.2":
   version: 1.5.2
   resolution: "@atlaskit/pragmatic-drag-and-drop@npm:1.5.2"
   dependencies:
@@ -689,12 +689,14 @@ __metadata:
   resolution: "pnp@workspace:."
   dependencies:
     "@atlaskit/pragmatic-drag-and-drop": "npm:^1.5.2"
+    "@custom/pragmatic-drag-and-drop": "npm:@atlaskit/pragmatic-drag-and-drop@^1.5.2"
     beachball: "npm:^2.52.0"
     custom-minimist: "npm:minimist@^1.2.8"
     is-even: "npm:^1.0.0"
     is-odd: "npm:^3.0.1"
     lib: "link:./shared"
     lodash.zip: "npm:^4.2.0"
+    pragmatic-drag-and-drop: "npm:@atlaskit/pragmatic-drag-and-drop@^1.5.2"
     preact: "npm:^10.26.5"
   languageName: unknown
   linkType: soft

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -144,6 +144,20 @@ fn resolve_npm_protocol_alias() {
             ".yarn/cache/minimist-npm-1.2.8-d7af7b1dce-19d3fcdca0.zip/node_modules/minimist/index.js"
         ))
     );
+
+    assert_eq!(
+        resolver.resolve(&fixture, "@custom/pragmatic-drag-and-drop").map(|r| r.full_path()),
+        Ok(fixture.join(
+            ".yarn/cache/@atlaskit-pragmatic-drag-and-drop-npm-1.5.2-3241d4f843-1dace49fa3.zip/node_modules/@atlaskit/pragmatic-drag-and-drop/dist/cjs/index.js"
+        ))
+    );
+
+    assert_eq!(
+        resolver.resolve(&fixture, "pragmatic-drag-and-drop").map(|r| r.full_path()),
+        Ok(fixture.join(
+            ".yarn/cache/@atlaskit-pragmatic-drag-and-drop-npm-1.5.2-3241d4f843-1dace49fa3.zip/node_modules/@atlaskit/pragmatic-drag-and-drop/dist/cjs/index.js"
+        ))
+    );
 }
 
 // Windows is blocked by upstream

--- a/src/tests/pnp.rs
+++ b/src/tests/pnp.rs
@@ -132,6 +132,20 @@ fn resolve_pnp_nested_package_json() {
     );
 }
 
+#[test]
+fn resolve_npm_protocol_alias() {
+    let fixture = super::fixture_root().join("pnp");
+
+    let resolver = Resolver::default();
+
+    assert_eq!(
+        resolver.resolve(&fixture, "custom-minimist").map(|r| r.full_path()),
+        Ok(fixture.join(
+            ".yarn/cache/minimist-npm-1.2.8-d7af7b1dce-19d3fcdca0.zip/node_modules/minimist/index.js"
+        ))
+    );
+}
+
 // Windows is blocked by upstream
 // see also https://github.com/yarnpkg/pnp-rs/pull/10
 #[cfg(not(windows))]


### PR DESCRIPTION
fix https://github.com/un-ts/eslint-plugin-import-x/issues/379

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix npm protocol alias resolution in `ResolverGeneric` and update Yarn version to 4.9.2 with new test added.
> 
>   - **Behavior**:
>     - Fixes npm protocol alias resolution in `ResolverGeneric` in `lib.rs` by using the specifier as the source of truth for package names.
>   - **Chores**:
>     - Updated Yarn version to 4.9.2 in `global-pnp/package.json` and `pnp/package.json`.
>     - Added alias "custom-minimist" for "minimist" in `pnp/package.json`.
>   - **Tests**:
>     - Added `resolve_npm_protocol_alias()` in `pnp.rs` to test npm protocol alias resolution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for ee31e61f93eb0d89f0a73834246e577adc3676a3. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Yarn package manager version to 4.9.2 in relevant configurations.
  - Added new dependency aliases for drag-and-drop packages and "custom-minimist" in one fixture.

- **Tests**
  - Introduced a new test to verify correct resolution of npm protocol aliases for dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->