### PR TITLE
fix: support extends in referenced project

### DIFF
--- a/fixtures/tsconfig/cases/project_references/extends/src/app.tsx
+++ b/fixtures/tsconfig/cases/project_references/extends/src/app.tsx
@@ -1,1 +1,0 @@
-export { Home } from '@/pages';

--- a/fixtures/tsconfig/cases/project_references/extends/src/app.tsx
+++ b/fixtures/tsconfig/cases/project_references/extends/src/app.tsx
@@ -1,0 +1,1 @@
+export { Home } from '@/pages';

--- a/fixtures/tsconfig/cases/project_references/extends/src/pages/index.tsx
+++ b/fixtures/tsconfig/cases/project_references/extends/src/pages/index.tsx
@@ -1,1 +1,0 @@
-export const Home = () => {};

--- a/fixtures/tsconfig/cases/project_references/extends/src/pages/index.tsx
+++ b/fixtures/tsconfig/cases/project_references/extends/src/pages/index.tsx
@@ -1,0 +1,1 @@
+export const Home = () => {};

--- a/fixtures/tsconfig/cases/project_references/extends/tsconfig.app.json
+++ b/fixtures/tsconfig/cases/project_references/extends/tsconfig.app.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig.base.json"
+}

--- a/fixtures/tsconfig/cases/project_references/extends/tsconfig.base.json
+++ b/fixtures/tsconfig/cases/project_references/extends/tsconfig.base.json
@@ -3,7 +3,7 @@
     "jsx": "react-jsx",
     "paths": {
       "@/*": ["${configDir}/src/*"]
-    },
+    }
   },
   "include": ["${configDir}/src"]
 }

--- a/fixtures/tsconfig/cases/project_references/extends/tsconfig.base.json
+++ b/fixtures/tsconfig/cases/project_references/extends/tsconfig.base.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["${configDir}/src/*"]
+    },
+  },
+  "include": ["${configDir}/src"]
+}

--- a/fixtures/tsconfig/cases/project_references/extends/tsconfig.json
+++ b/fixtures/tsconfig/cases/project_references/extends/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/fixtures/tsconfig/cases/project_references/extends/tsconfig.json
+++ b/fixtures/tsconfig/cases/project_references/extends/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "files": [],
   "references": [
-    { "path": "./tsconfig.app.json" }
+    {
+      "path": "./tsconfig.app.json"
+    }
   ]
 }

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -228,6 +228,7 @@ fn references_with_extends() {
     let f = super::fixture_root().join("tsconfig/cases/project_references/extends");
 
     let resolver = Resolver::new(ResolveOptions {
+        extensions: vec![".ts".into(), ".tsx".into()],
         tsconfig: Some(TsconfigOptions {
             config_file: f.clone(),
             references: TsconfigReferences::Auto,
@@ -235,7 +236,7 @@ fn references_with_extends() {
         ..ResolveOptions::default()
     });
 
-    let resolved_path = resolver.resolve(&f.join("src"), "@/pages").map(|f| f.full_path());
+    let resolved_path = resolver.resolve(f.join("src"), "@/pages").map(|f| f.full_path());
 
     assert_eq!(resolved_path, Ok(f.join("src/pages/index.tsx")));
 }

--- a/src/tests/tsconfig_project_references.rs
+++ b/src/tests/tsconfig_project_references.rs
@@ -222,3 +222,20 @@ fn self_reference() {
         );
     }
 }
+
+#[test]
+fn references_with_extends() {
+    let f = super::fixture_root().join("tsconfig/cases/project_references/extends");
+
+    let resolver = Resolver::new(ResolveOptions {
+        tsconfig: Some(TsconfigOptions {
+            config_file: f.clone(),
+            references: TsconfigReferences::Auto,
+        }),
+        ..ResolveOptions::default()
+    });
+
+    let resolved_path = resolver.resolve(&f.join("src"), "@/pages").map(|f| f.full_path());
+
+    assert_eq!(resolved_path, Ok(f.join("src/pages/index.tsx")));
+}


### PR DESCRIPTION
fix https://github.com/import-js/eslint-import-resolver-typescript/issues/400
close #138

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor TypeScript configuration extension logic and add tests to support module path resolution with project references and configuration inheritance.
> 
>   - **Behavior**:
>     - Refactor `extend_tsconfig` logic in `lib.rs` to handle TypeScript configuration extensions in referenced projects.
>     - Add `extend_tsconfig` function to encapsulate extension logic in `lib.rs`.
>   - **Tests**:
>     - Add `references_with_extends` test in `tsconfig_project_references.rs` to verify module path resolution with TypeScript project references and configuration inheritance.
>   - **Configuration**:
>     - Add `tsconfig.app.json` and `tsconfig.base.json` to demonstrate configuration inheritance in `fixtures/tsconfig/cases/project_references/extends`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for b2878f66ce1aae9ea04aa69a1b5ace89f5c16c86. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new React component named Home.
  - Added new TypeScript configuration files to support project references and JSX handling.
- **Tests**
  - Added a test to verify correct resolution of aliased paths with project references and extended tsconfig files.
- **Refactor**
  - Improved internal handling of TypeScript configuration extension logic for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->