### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/unrs/unrs-resolver/compare/v1.7.13...v2.0.0) - 2025-06-11
+
+### <!-- 0 -->Features
+
+- support runtime fallback for webcontainer ([#144](https://github.com/unrs/unrs-resolver/pull/144)) (by @JounQin) - #144
+
+### <!-- 7 -->Chore
+
+- *(deps)* update all dependencies ([#141](https://github.com/unrs/unrs-resolver/pull/141)) (by @renovate[bot])
+
+### Contributors
+
+* @JounQin
+* @renovate[bot]
+
 ## [1.7.13](https://github.com/unrs/unrs-resolver/compare/v1.7.12...v1.7.13) - 2025-06-10
 
 ### <!-- 1 -->Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/unrs/unrs-resolver/compare/v1.7.13...v2.0.0) - 2025-06-11
+## [1.8.0](https://github.com/unrs/unrs-resolver/compare/v1.7.13...v1.8.0) - 2025-06-11
 
 ### <!-- 0 -->Features
 
 - support runtime fallback for webcontainer ([#144](https://github.com/unrs/unrs-resolver/pull/144)) (by @JounQin) - #144
+- merge from upstream `oxc-project/oxc-resolver` - 6th ([#146](https://github.com/unrs/unrs-resolver/pull/146)) (by @JounQin) - #146
 
 ### <!-- 7 -->Chore
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.7.13"
+version = "2.0.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "2.0.0"
+version = "1.8.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-unrs_resolver = { version = "1.7.13", path = "." }
+unrs_resolver = { version = "2.0.0", path = "." }
 
 [package]
 name = "unrs_resolver"
-version = "1.7.13"
+version = "2.0.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-unrs_resolver = { version = "2.0.0", path = "." }
+unrs_resolver = { version = "1.8.0", path = "." }
 
 [package]
 name = "unrs_resolver"
-version = "2.0.0"
+version = "1.8.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "2.0.0",
+  "version": "1.8.0",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -21,7 +21,7 @@
     "build": "pnpm build:debug --features allocator --release",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
     "postbuild": "node napi/patch.mjs",
-    "postinstall": "napi-postinstall unrs-resolver 2.0.0 check",
+    "postinstall": "napi-postinstall unrs-resolver 1.8.0 check",
     "prepublishOnly": "clean-pkg-json",
     "test": "vitest run -r ./napi"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.7.13",
+  "version": "2.0.0",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -21,7 +21,7 @@
     "build": "pnpm build:debug --features allocator --release",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
     "postbuild": "node napi/patch.mjs",
-    "postinstall": "napi-postinstall unrs-resolver 1.7.13 check",
+    "postinstall": "napi-postinstall unrs-resolver 2.0.0 check",
     "prepublishOnly": "clean-pkg-json",
     "test": "vitest run -r ./napi"
   },


### PR DESCRIPTION



## 🤖 New release

* `unrs_resolver`: 1.7.13 -> 2.0.0 (⚠ API breaking changes)

### ⚠ `unrs_resolver` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ResolveOptions.module_type in /tmp/.tmpCnHCfn/unrs-resolver/src/options.rs:184

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ResolveError::JSON, previously in file /tmp/.tmpeLByK0/unrs_resolver/src/error.rs:74

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  unrs_resolver::ResolveError::from_serde_json_error now takes 2 parameters instead of 3, in /tmp/.tmpCnHCfn/unrs-resolver/src/error.rs:117

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field content of struct JSONError, previously in file /tmp/.tmpeLByK0/unrs_resolver/src/error.rs:146

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method unrs_resolver::CachedPath::is_node_modules in file /tmp/.tmpCnHCfn/unrs-resolver/src/cache.rs:65
  trait method unrs_resolver::CachedPath::inside_node_modules in file /tmp/.tmpCnHCfn/unrs-resolver/src/cache.rs:67

--- failure trait_method_requires_different_generic_type_params: trait method now requires a different number of generic type parameters ---

Description:
A trait method now requires a different number of generic type parameters than it used to. Calls or implementations of this trait method using the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_requires_different_generic_type_params.ron

Failed in:
  CachedPath::normalize_with (1 -> 2 generic types) in /tmp/.tmpCnHCfn/unrs-resolver/src/cache.rs:96
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/unrs/unrs-resolver/compare/v1.7.13...v2.0.0) - 2025-06-11

### <!-- 0 -->Features

- support runtime fallback for webcontainer ([#144](https://github.com/unrs/unrs-resolver/pull/144)) (by @JounQin) - #144

### <!-- 7 -->Chore

- *(deps)* update all dependencies ([#141](https://github.com/unrs/unrs-resolver/pull/141)) (by @renovate[bot])

### Contributors

* @JounQin
* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Release version 1.8.0 of `unrs_resolver` with updated dependencies and documentation.
> 
>   - **Version Update**:
>     - Bump `unrs_resolver` version to 1.8.0 in `Cargo.toml`, `Cargo.lock`, and `package.json`.
>   - **Dependencies**:
>     - Update all dependencies to their latest versions.
>   - **Scripts**:
>     - Update `postinstall` script in `package.json` to use version 1.8.0.
>   - **Documentation**:
>     - Add changelog entry for version 1.8.0, including new features and contributors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for bc7a60b49eb2d184157b31b9feac0442ce4421eb. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated package version to 1.8.0.
  - Upgraded all dependencies.
  - Updated post-install scripts to reflect the new version.
- **Documentation**
  - Added a changelog entry for version 1.8.0, highlighting new features and contributors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->