### PR TITLE
fix: keep `napi` property in `package.json` for `napi-postinstall`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1](https://github.com/unrs/unrs-resolver/compare/v1.8.0...v1.8.1) - 2025-06-11
+
+### <!-- 1 -->Bug Fixes
+
+- keep `napi` property in `package.json` for `napi-postinstall` ([#148](https://github.com/unrs/unrs-resolver/pull/148)) (by @JounQin)
+
+### Contributors
+
+* @JounQin
+
 ## [1.8.0](https://github.com/unrs/unrs-resolver/compare/v1.7.13...v1.8.0) - 2025-06-11
 
 ### <!-- 0 -->Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-unrs_resolver = { version = "1.8.0", path = "." }
+unrs_resolver = { version = "1.8.1", path = "." }
 
 [package]
 name = "unrs_resolver"
-version = "1.8.0"
+version = "1.8.1"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -21,8 +21,8 @@
     "build": "pnpm build:debug --features allocator --release",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
     "postbuild": "node napi/patch.mjs",
-    "postinstall": "napi-postinstall unrs-resolver 1.8.0 check",
-    "prepublishOnly": "clean-pkg-json",
+    "postinstall": "napi-postinstall unrs-resolver 1.8.1 check",
+    "prepublishOnly": "clean-pkg-json -k napi",
     "test": "vitest run -r ./napi"
   },
   "dependencies": {


### PR DESCRIPTION
close #147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the correct handling of the `napi` property in the installation process to support post-install scripts.

- **Chores**
  - Updated version numbers to 1.8.1 across relevant files.
  - Adjusted internal scripts to align with the new version and maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->