### PR TITLE
fix: try different approach to support web container out of box

### DIFF
--- a/napi/test.mjs
+++ b/napi/test.mjs
@@ -7,26 +7,34 @@ console.log(`Testing on ${process.platform}-${process.arch}`);
 const dir = import.meta.dirname;
 
 // `resolve`
-assert.deepStrictEqual(resolve.sync(dir, './index.js').path, path.join(dir, 'index.js'));
+assert.deepStrictEqual(
+  resolve.sync(dir, './index.js').path,
+  path.join(dir, 'index.js'),
+);
 
 // `ResolverFactory`
 const resolver = new ResolverFactory();
-assert.deepStrictEqual(resolver.sync(dir, './index.js').path, path.join(dir, 'index.js'));
+assert.deepStrictEqual(
+  resolver.sync(dir, './index.js').path,
+  path.join(dir, 'index.js'),
+);
 
 assert.strict(resolver.sync(dir, './ts').error.length > 0);
 
-resolver.async(dir, './ts')
+resolver
+  .async(dir, './ts')
   .then((result) => assert.strict(result.error.length > 0));
 
 const newResolver = resolver.cloneWithOptions({});
 newResolver.clearCache();
 
 // custom constructor
-const resolver2 = new ResolverFactory(
-  {
-    extensions: ['.mjs'],
-  },
-);
+const resolver2 = new ResolverFactory({
+  extensions: ['.mjs'],
+});
 
 // After add `.ts` extension, resolver can resolve `ts` as `ts.ts` now
-assert.deepStrictEqual(resolver2.sync(dir, './test.mjs').path, path.join(dir, 'test.mjs'));
+assert.deepStrictEqual(
+  resolver2.sync(dir, './test.mjs').path,
+  path.join(dir, 'test.mjs'),
+);

--- a/napi/tests/simple.test.mjs
+++ b/napi/tests/simple.test.mjs
@@ -16,7 +16,8 @@ test('simple', () => {
 
   assert.isAbove(resolver.sync(cwd, './ts').error.length, 0);
 
-  resolver.async(cwd, './ts')
+  resolver
+    .async(cwd, './ts')
     .then((result) => assert.isAbove(result.error.length, 0));
 
   // Test API
@@ -32,12 +33,18 @@ test('module_type', () => {
     moduleType: true,
   });
 
-  assert.equal(esmResolver.sync(dir, 'minimatch').moduleType, ModuleType.Module);
+  assert.equal(
+    esmResolver.sync(dir, 'minimatch').moduleType,
+    ModuleType.Module,
+  );
 
   const cjsResolver = esmResolver.cloneWithOptions({
     conditionNames: ['node', 'require'],
     moduleType: true,
   });
 
-  assert.equal(cjsResolver.sync(dir, 'minimatch').moduleType, ModuleType.CommonJs);
+  assert.equal(
+    cjsResolver.sync(dir, 'minimatch').moduleType,
+    ModuleType.CommonJs,
+  );
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved compatibility for WebContainer environments by automatically installing and loading the required WASI binding package when needed.

- **Style**
  - Reformatted test files for better readability and consistent code style.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances WebContainer support by auto-installing WASI bindings and improves test file readability.
> 
>   - **WebContainer Support**:
>     - In `napi/fallback.js`, added logic to detect WebContainer environments and automatically install `@unrs/resolver-binding-wasm32-wasi` package if not present.
>     - Uses `execFileSync` to run package manager commands for installation.
>   - **Style Improvements**:
>     - Reformatted assertions and promise chains in `napi/test.mjs` and `napi/tests/simple.test.mjs` for better readability and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 06a2e098987145df9f5729ac127c70e0b5eb89a9. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->