### PR TITLE
chore: release v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1](https://github.com/unrs/unrs-resolver/compare/v1.9.0...v1.9.1) - 2025-06-20
+
+### <!-- 1 -->Bug Fixes
+
+- *(deps)* update all dependencies ([#157](https://github.com/unrs/unrs-resolver/pull/157)) (by @renovate[bot])
+
+### Contributors
+
+* @renovate[bot]
+
 ## [1.9.0](https://github.com/unrs/unrs-resolver/compare/v1.8.1...v1.9.0) - 2025-06-11
 
 ### <!-- 0 -->Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-unrs_resolver = { version = "1.9.0", path = "." }
+unrs_resolver = { version = "1.9.1", path = "." }
 
 [package]
 name = "unrs_resolver"
-version = "1.9.0"
+version = "1.9.1"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -21,7 +21,7 @@
     "build": "pnpm build:debug --features allocator --release",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
     "postbuild": "node napi/patch.mjs",
-    "postinstall": "napi-postinstall unrs-resolver 1.9.0 check",
+    "postinstall": "napi-postinstall unrs-resolver 1.9.1 check",
     "prepublishOnly": "clean-pkg-json -k napi",
     "test": "vitest run -r ./napi"
   },


### PR DESCRIPTION



## 🤖 New release

* `unrs_resolver`: 1.9.0 -> 1.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.9.1](https://github.com/unrs/unrs-resolver/compare/v1.9.0...v1.9.1) - 2025-06-20

### <!-- 1 -->Bug Fixes

- *(deps)* update all dependencies ([#157](https://github.com/unrs/unrs-resolver/pull/157)) (by @renovate[bot])

### Contributors

* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `unrs_resolver` to v1.9.1 with updated dependencies.
> 
>   - **Version Update**:
>     - Bump `unrs_resolver` version from 1.9.0 to 1.9.1 in `Cargo.toml` and `Cargo.lock`.
>   - **Dependency Updates**:
>     - Update all dependencies to their latest versions as per `CHANGELOG.md`.
>   - **Changelog**:
>     - Add entry for version 1.9.1 in `CHANGELOG.md` noting dependency updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 2757e189a051dbad3dbfc0e00fb6344b4284be7d. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated project version to 1.9.1.
  - Updated dependencies to their latest versions.
  - Revised changelog to include details for version 1.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->