### PR TITLE
fix: requiring `.` or `./` should respect `mainFiles` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ An **absolute** path to a directory where the specifier is resolved against.
 
 For CommonJS modules, it is the `__dirname` variable that contains the absolute path to the folder containing current module.
 
-For ECMAScript modules, it is the value of `import.meta.url`.
+For ECMAScript modules, it is the value of `import.meta.dirname`.
 
 Behavior is undefined when given a path to a file.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -498,18 +498,12 @@ impl<C: Cache<Cp = FsCachedPath>> ResolverGeneric<C> {
         let cached_path = cached_path.normalize_with(specifier, self.cache.as_ref());
         // a. LOAD_AS_FILE(Y + X)
         // b. LOAD_AS_DIRECTORY(Y + X)
-        if !self.options.fully_specified && (specifier == "." || specifier == "./") {
-            let sub_path =
-                if self.cache.is_dir(&cached_path, ctx) { "./index.js" } else { "../index.js" };
-            let cached_path = cached_path.clone().normalize_with(sub_path, self.cache.as_ref());
-            if self.cache.is_file(&cached_path, ctx) {
-                return Ok(cached_path);
-            }
-            if let Some(path) = self.load_as_file(&cached_path, ctx)? {
-                return Ok(path);
-            }
-        }
-        if let Some(path) = self.load_as_file_or_directory(&cached_path, specifier, ctx)? {
+        if let Some(path) = self.load_as_file_or_directory(
+            &cached_path,
+            // ensure resolve directory only when specifier is `.`
+            if specifier == "." { "./" } else { specifier },
+            ctx,
+        )? {
             return Ok(path);
         }
         // c. THROW "not found"

--- a/src/tests/incorrect_description_file.rs
+++ b/src/tests/incorrect_description_file.rs
@@ -17,11 +17,8 @@ fn incorrect_description_file_1() {
         column: 0,
     });
     assert_eq!(resolution, Err(error));
-    assert_eq!(
-        ctx.file_dependencies,
-        FxHashSet::from_iter([f.join("pack1"), f.join("pack1/package.json")])
-    );
-    assert!(!ctx.missing_dependencies.is_empty());
+    assert_eq!(ctx.file_dependencies, FxHashSet::from_iter([f.join("pack1/package.json")]));
+    assert!(ctx.missing_dependencies.is_empty());
 }
 
 // should not resolve main in incorrect description file #2

--- a/src/tests/resolve.rs
+++ b/src/tests/resolve.rs
@@ -154,18 +154,26 @@ fn prefer_file_over_dir() {
 fn resolve_dot() {
     let f = super::fixture_root().join("dot");
     let foo_dir: std::path::PathBuf = f.join("foo");
-    let foo_dir_foo = foo_dir.join("foo.js");
     let resolver = Resolver::default();
     let foo_index = foo_dir.join("index.js");
     let data = [
-        ("dot file", foo_dir_foo.clone(), ".", foo_index.clone()),
-        ("dot file slash", foo_dir_foo, "./", foo_index.clone()),
         ("dot dir", foo_dir.clone(), ".", foo_index.clone()),
-        ("dot dir slash", foo_dir, "./", foo_index),
+        ("dot dir slash", foo_dir.clone(), "./", foo_index),
     ];
     for (comment, path, request, expected) in data {
         let resolved_path = resolver.resolve(&path, request).map(|r| r.full_path());
         assert_eq!(resolved_path, Ok(expected), "{comment} {path:?} {request}");
+    }
+
+    let resolver =
+        Resolver::new(ResolveOptions { main_files: vec![], ..ResolveOptions::default() });
+    let data = [
+        ("dot dir", foo_dir.clone(), ".", ResolveError::NotFound(".".into())),
+        ("dot dir slash", foo_dir, "./", ResolveError::NotFound("./".into())),
+    ];
+    for (comment, path, request, expected) in data {
+        let resolve_error = resolver.resolve(&path, request);
+        assert_eq!(resolve_error, Err(expected), "{comment} {path:?} {request}");
     }
 }
 


### PR DESCRIPTION
close #160

related #121 and #123, the first argument is `directory`, should never be `file`.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes directory resolution for `.` and `./` specifiers to respect `mainFiles` option, with updates to tests and documentation.
> 
>   - **Behavior**:
>     - Adjusts `require_relative()` in `src/lib.rs` to handle `.` and `./` specifiers by ensuring directories are resolved only when the specifier is `.`.
>     - Updates `load_as_file_or_directory()` to respect `mainFiles` option when resolving directories.
>   - **Tests**:
>     - Modifies `resolve_dot()` in `src/tests/resolve.rs` to test new behavior for `.` and `./` specifiers with and without `mainFiles`.
>     - Updates `incorrect_description_file_1()` in `src/tests/incorrect_description_file.rs` to check for empty `missing_dependencies`.
>   - **Documentation**:
>     - Fixes typo in `README.md` changing `import.meta.url` to `import.meta.dirname`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 9d827099676117bc33a891a7257a9814edf488c7. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify the reference for ECMAScript module directories, changing from `import.meta.url` to `import.meta.dirname`.

- **Bug Fixes**
  - Adjusted test expectations for file and missing dependencies after a failed resolution due to an incorrect description file.

- **Refactor**
  - Simplified the logic for resolving relative paths, streamlining how directory and file resolution is handled.

- **Tests**
  - Updated and expanded tests to better reflect resolver behavior, including handling of missing main files and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->