### PR TITLE
chore: release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0](https://github.com/unrs/unrs-resolver/compare/v1.9.2...v2.0.0) - 2025-07-02
+## [1.10.0](https://github.com/unrs/unrs-resolver/compare/v1.9.2...v1.10.0) - 2025-07-02
 
 ### <!-- 1 -->🐛 Bug Fixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "2.0.0"
+version = "1.10.0"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-unrs_resolver = { version = "2.0.0", path = "." }
+unrs_resolver = { version = "1.10.0", path = "." }
 
 [package]
 name = "unrs_resolver"
-version = "2.0.0"
+version = "1.10.0"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "2.0.0",
+  "version": "1.10.0",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -20,7 +20,7 @@
     "build": "pnpm build:debug --features allocator --release",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
     "postbuild:debug": "node napi/patch.mjs",
-    "postinstall": "napi-postinstall unrs-resolver 2.0.0 check",
+    "postinstall": "napi-postinstall unrs-resolver 1.10.0 check",
     "prepublishOnly": "clean-pkg-json -k napi",
     "test": "vitest run -r ./napi"
   },


### PR DESCRIPTION


## 🤖 New release

* `unrs_resolver`: 1.9.2 -> 1.10.0 (⚠ API breaking changes)

### ⚠ `unrs_resolver` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ResolveOptions.yarn_pnp in /tmp/.tmpCXIbDF/unrs-resolver/src/options.rs:125
  field ResolveOptions.allow_package_exports_in_directory_resolve in /tmp/.tmpCXIbDF/unrs-resolver/src/options.rs:194

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field enable_pnp of struct ResolveOptions, previously in file /tmp/.tmpt5sPQm/unrs_resolver/src/options.rs:53

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method unrs_resolver::PathUtil::normalize_relative in file /tmp/.tmpCXIbDF/unrs-resolver/src/path.rs:20

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method read of trait FileSystem, previously in file /tmp/.tmpt5sPQm/unrs_resolver/src/file_system.rs:19
  method canonicalize of trait FileSystem, previously in file /tmp/.tmpt5sPQm/unrs_resolver/src/file_system.rs:77
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.10.0](https://github.com/unrs/unrs-resolver/compare/v1.9.2...v1.10.0) - 2025-07-02

### <!-- 1 -->🐛 Bug Fixes

- support resolving abnormal relative paths with `node_modules` ([#171](https://github.com/unrs/unrs-resolver/pull/171)) (by @JounQin) - #171
- *(deps)* update all dependencies ([#168](https://github.com/unrs/unrs-resolver/pull/168)) (by @renovate[bot])

### <!-- 9 -->💼 Other

- Merge remote-tracking branch 'upstream/main' into chore/merge_upstream (by @JounQin) - #174

### Contributors

* @JounQin
* @renovate[bot]
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Release version 1.10.0 of `unrs_resolver` with bug fixes, dependency updates, and version bump in relevant files.
> 
>   - **Version Update**:
>     - Bump `unrs_resolver` version from 1.9.2 to 1.10.0 in `Cargo.toml`, `Cargo.lock`, and `package.json`.
>   - **Changelog**:
>     - Add entry for version 1.10.0 in `CHANGELOG.md` with bug fixes and dependency updates.
>   - **Bug Fixes**:
>     - Support resolving abnormal relative paths with `node_modules`.
>   - **Dependencies**:
>     - Update all dependencies to latest versions.
>   - **Misc**:
>     - Merge remote-tracking branch 'upstream/main'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for e4f1e62d5a006adcbb8366dcfff3a04cea471d99. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog with details for version 1.10.0, including a bug fix for resolving abnormal relative paths and dependency updates.
  * Bumped package version to 1.10.0 across relevant configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->