### PR TITLE
chore: update all left references, add WASM example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ const resolver = new ResolverFactory();
 assert(resolver.sync(process.cwd(), './index.js').path, path.resolve('index.js'));
 ```
 
+### Supports WASM
+
+See https://stackblitz.com/edit/unrs-resolver for usage example.
+
 ### Rust
 
 See [docs.rs/unrs_resolver](https://docs.rs/unrs_resolver/latest/unrs_resolver/).
@@ -220,14 +224,14 @@ See [index.d.ts](https://github.com/unrs/unrs-resolver/blob/main/napi/index.d.ts
 
 ## Debugging
 
-The following environment variable emits tracing information for the `oxc_resolver::resolve` function.
+The following environment variable emits tracing information for the `unrs_resolver::resolve` function.
 
 e.g.
 
 ```
-2024-06-11T07:12:20.003537Z DEBUG oxc_resolver: options: ResolveOptions { ... }, path: "...", specifier: "...", ret: "..."
-    at /path/to/oxc_resolver-1.8.1/src/lib.rs:212
-    in oxc_resolver::resolve with path: "...", specifier: "..."
+2024-06-11T07:12:20.003537Z DEBUG unrs_resolver: options: ResolveOptions { ... }, path: "...", specifier: "...", ret: "..."
+    at /path/to/unrs_resolver-1.8.1/src/lib.rs:212
+    in unrs_resolver::resolve with path: "...", specifier: "..."
 ```
 
 The input values are `options`, `path` and `specifier`, the returned value is `ret`.
@@ -255,11 +259,11 @@ Test cases are located in `./src/tests`, fixtures are located in `./tests`
 - [x] extensions.test.js
 - [x] fallback.test.js
 - [x] fullSpecified.test.js
-- [x] identifier.test.js (see unit test in `crates/oxc_resolver/src/request.rs`)
+- [x] identifier.test.js (see unit test in `crates/unrs_resolver/src/request.rs`)
 - [x] importsField.test.js
 - [x] incorrect-description-file.test.js (need to add ctx.fileDependencies)
 - [x] missing.test.js
-- [x] path.test.js (see unit test in `crates/oxc_resolver/src/path.rs`)
+- [x] path.test.js (see unit test in `crates/unrs_resolver/src/path.rs`)
 - [ ] plugins.test.js
 - [ ] pnp.test.js
 - [x] resolve.test.js

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resolver_fuzz"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 # Use independent workspace for fuzzers
@@ -20,4 +20,4 @@ bench = false
 
 [dependencies]
 libfuzzer-sys = "0.4.7"
-oxc_resolver = { path = ".." }
+unrs_resolver = { path = ".." }

--- a/fuzz/fuzz_targets/resolver.rs
+++ b/fuzz/fuzz_targets/resolver.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use oxc_resolver::Resolver;
+use unrs_resolver::Resolver;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update references to `unrs_resolver`, add WASM example, and update Rust edition in `Cargo.toml`.
> 
>   - **Documentation**:
>     - Updated references in documentation and examples to reflect the new package name `unrs_resolver`.
>     - Added a "Supports WASM" section with a usage example link in `README.md`.
>     - Clarified and corrected environment variable names for debugging in `README.md`.
>     - Removed outdated "Rolldown" subsection and related content in `README.md`.
>   - **Chores**:
>     - Updated internal dependencies and imports to use the new package name `unrs_resolver` in `fuzz/fuzz_targets/resolver.rs` and `fuzz/Cargo.toml`.
>     - Updated Rust edition to "2024" in `fuzz/Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 8f62d750def38bb85d407de512b267ce87a4c788. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references in documentation and examples to reflect the new package name.
  * Added a "Supports WASM" section with a usage example link.
  * Clarified and corrected environment variable names for debugging.
  * Removed outdated "Rolldown" subsection and related content.

* **Chores**
  * Updated internal dependencies and imports to use the new package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->