### PR TITLE
chore: release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1](https://github.com/unrs/unrs-resolver/compare/v1.10.0...v1.10.1) - 2025-07-02
+
+### <!-- 1 -->🐛 Bug Fixes
+
+- fix: incorrect package.json relative path ([#176](https://github.com/unrs/unrs-resolver/pull/176)) (by @JounQin) - #176
+
+### Contributors
+
+* @JounQin
+
 ## [1.10.0](https://github.com/unrs/unrs-resolver/compare/v1.9.2...v1.10.0) - 2025-07-02
 
 ### <!-- 1 -->🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unrs_resolver"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
  "cfg-if",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ rust-version = "1.85.0"
 description = "ESM / CJS module resolution"
 
 [workspace.dependencies]
-unrs_resolver = { version = "1.10.0", path = "." }
+unrs_resolver = { version = "1.10.1", path = "." }
 
 [package]
 name = "unrs_resolver"
-version = "1.10.0"
+version = "1.10.1"
 authors.workspace = true
 categories.workspace = true
 edition.workspace = true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unrs-resolver",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "type": "commonjs",
   "description": "UnRS Resolver Node API with PNP support",
   "repository": "git+https://github.com/unrs/unrs-resolver.git",
@@ -20,7 +20,7 @@
     "build": "pnpm build:debug --features allocator --release",
     "build:debug": "napi build --platform --manifest-path napi/Cargo.toml",
     "postbuild:debug": "node napi/patch.mjs",
-    "postinstall": "napi-postinstall unrs-resolver 1.10.0 check",
+    "postinstall": "napi-postinstall unrs-resolver 1.10.1 check",
     "prepublishOnly": "clean-pkg-json -k napi",
     "test": "vitest run -r ./napi"
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `unrs_resolver` version to `1.10.1` with a bug fix for `package.json` path.
> 
>   - **Version Bump**:
>     - Update `unrs_resolver` version from `1.10.0` to `1.10.1` in `Cargo.toml`, `Cargo.lock`, and `package.json`.
>   - **Changelog**:
>     - Add entry for version `1.10.1` in `CHANGELOG.md` noting a bug fix for incorrect `package.json` path.
>   - **Misc**:
>     - Update `postinstall` script in `package.json` to use version `1.10.1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 9a1c8cd6221054c83c6c8c7ad5d99f8eb7cdafb8. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers to 1.10.1 across project files.
  * Added a new release entry for version 1.10.1 to the changelog.
* **Bug Fixes**
  * Fixed an incorrect relative path in the postinstall script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->