### PR TITLE
Add loongarch64 support

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -100,6 +100,18 @@ jobs:
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
             build: export CFLAGS="-fuse-ld=lld" && pnpm build --use-napi-cross
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            build: |-
+              sudo apt-get update &&
+              sudo apt-get install gcc-13-loongarch64-linux-gnu g++-13-loongarch64-linux-gnu -y &&
+              export CC_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-gcc-13 &&
+              export CXX_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-g++-13 &&
+              export CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc-13 &&
+              pnpm build
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+            build: pnpm build -x
           - os: macos-latest
             target: x86_64-apple-darwin
             build: pnpm build
@@ -125,7 +137,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Build
         run: ${{ matrix.build }} --target ${{ matrix.target }}

--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -100,6 +100,18 @@ jobs:
           - os: ubuntu-latest
             target: s390x-unknown-linux-gnu
             build: export CFLAGS="-fuse-ld=lld" && pnpm build --use-napi-cross
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-gnu
+            build: |-
+              sudo apt-get update &&
+              sudo apt-get install gcc-13-loongarch64-linux-gnu g++-13-loongarch64-linux-gnu -y &&
+              export CC_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-gcc-13 &&
+              export CXX_loongarch64_unknown_linux_gnu=loongarch64-linux-gnu-g++-13 &&
+              export CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-linux-gnu-gcc-13 &&
+              pnpm build
+          - os: ubuntu-latest
+            target: loongarch64-unknown-linux-musl
+            build: pnpm build -x
           - os: macos-latest
             target: x86_64-apple-darwin
             build: pnpm build
@@ -132,7 +144,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}
         with:
-          version: 0.13.0
+          version: 0.14.0
 
       - name: Build
         run: ${{ matrix.build }} --target ${{ matrix.target }}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "napi-postinstall": "^0.3.0"
   },
   "devDependencies": {
-    "@napi-rs/cli": "3.0.0-alpha.92",
+    "@napi-rs/cli": "3.3.1",
     "@napi-rs/wasm-runtime": "^0.2.11",
     "@types/node": "^22.16.0",
     "clean-pkg-json": "^1.3.0",
@@ -67,6 +67,8 @@
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",
       "s390x-unknown-linux-gnu",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "x86_64-apple-darwin",
       "aarch64-apple-darwin",
       "wasm32-wasip1-threads"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
       "armv7-unknown-linux-gnueabihf",
       "armv7-unknown-linux-musleabihf",
       "i686-pc-windows-msvc",
+      "loongarch64-unknown-linux-gnu",
+      "loongarch64-unknown-linux-musl",
       "powerpc64le-unknown-linux-gnu",
       "riscv64gc-unknown-linux-gnu",
       "riscv64gc-unknown-linux-musl",


### PR DESCRIPTION
Can we increase support for the loongarch64 architecture? I can build a .node file for loongarch64 using Docker image of ubuntu:latest  and versions of Zig 0.14.0 and @ napi-rs/cli 3.3.1
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add loongarch64 architecture support and update version handling for native bindings.
> 
>   - **Architecture Support**:
>     - Add `loongarch64-unknown-linux-gnu` and `loongarch64-unknown-linux-musl` targets in `.github/workflows/release-napi.yml` and `package.json`.
>     - Update `requireNative()` in `napi/index.js` to handle `loong64` architecture.
>   - **Version Handling**:
>     - Add version mismatch check for native bindings in `requireNative()` in `napi/index.js`.
>   - **Dependencies**:
>     - Update `@napi-rs/cli` to version `3.3.1` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=unrs%2Funrs-resolver&utm_source=github&utm_medium=referral)<sup> for 4d0b2084a6c2ae05564658f03dab13c870ea0bb8. You can [customize](https://app.ellipsis.dev/unrs/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded platform support by adding Loongarch64 targets (GNU/Linux and musl variants) to the build and release pipeline.
  * Updated build tooling to a newer release for improved compatibility and smoother builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unrs/unrs-resolver/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->