### PR TITLE
ci: migrate release Zig setup action

### DIFF
--- a/.github/workflows/release-napi.yml
+++ b/.github/workflows/release-napi.yml
@@ -141,7 +141,7 @@ jobs:
         if: ${{ contains(matrix.target, 'ohos') }}
         uses: Boshen/setup-ohos-sdk@edb865a89a712f1f15dbad932dfa9cfce849d95c # v1.0.0
 
-      - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         if: ${{ contains(matrix.target, 'musl') }}
         with:
           version: 0.14.0


### PR DESCRIPTION
## Summary
- Replace `goto-bus-stop/setup-zig` with `mlugg/setup-zig` in the NAPI release workflow
- Keep the action pinned to the `v2.2.1` commit and preserve Zig `0.14.0`

## Test plan
- [x] `just ready`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow dependencies to maintain compatibility with the release pipeline.

---

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unrs/unrs-resolver/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->