### PR TITLE
fix: gate statx dont-sync flag for loongarch64 musl

### DIFF
--- a/src/file_system.rs
+++ b/src/file_system.rs
@@ -173,7 +173,11 @@ impl FileSystemOs {
                 Ok(result.into())
             } else if #[cfg(target_os = "linux")] {
                 use rustix::fs::{AtFlags, CWD, FileType, StatxFlags};
-                match rustix::fs::statx(CWD, path, AtFlags::STATX_DONT_SYNC, StatxFlags::TYPE) {
+                #[cfg(all(target_arch = "loongarch64", target_env = "musl"))]
+                let flags = AtFlags::empty();
+                #[cfg(not(all(target_arch = "loongarch64", target_env = "musl")))]
+                let flags = AtFlags::STATX_DONT_SYNC;
+                match rustix::fs::statx(CWD, path, flags, StatxFlags::TYPE) {
                     Ok(statx) => {
                         let file_type = FileType::from_raw_mode(statx.stx_mode.into());
                         Ok(FileMetadata::new(file_type.is_file(), file_type.is_dir(), file_type.is_symlink()))


### PR DESCRIPTION
## Summary
- Avoid referencing `AtFlags::STATX_DONT_SYNC` on `loongarch64-unknown-linux-musl`, where rustix does not expose it.
- Keep using `STATX_DONT_SYNC` on other Linux targets.

## Test plan
- [x] `cargo check --target loongarch64-unknown-linux-musl`
- [x] `cargo check --target riscv64gc-unknown-linux-musl`
- [x] `just ready`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file system metadata retrieval on Linux for enhanced platform compatibility, particularly for loongarch64 architecture environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unrs/unrs-resolver/pull/209?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->